### PR TITLE
Add initial Linux support for building HenSurf

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,17 +20,49 @@ if [ ! -f "chromium/src/out/HenSurf/args.gn" ]; then
 fi
 
 # Add depot_tools to PATH
-export PATH="$PWD/../depot_tools:$PATH"
+# Corrected path: install-deps.sh places depot_tools alongside the project root (e.g. ../depot_tools if project is HenSurf)
+# This script cds into chromium/src, so from there, depot_tools is ../../depot_tools
 
 cd chromium/src
+
+# IMPORTANT: Set path to depot_tools, assuming it's two levels up from chromium/src
+# e.g. if project is /path/to/HenSurf, depot_tools is /path/to/depot_tools
+# and current dir is /path/to/HenSurf/chromium/src
+export PATH="$PWD/../../depot_tools:$PATH"
+
 
 # Check system requirements
 echo "🔍 Checking system requirements..."
 
-# Check available memory (recommend 16GB+)
-MEMORY_GB=$(sysctl -n hw.memsize | awk '{print int($1/1024/1024/1024)}')
+MEMORY_GB=0
+CPU_CORES=1 # Default to 1 core if detection fails
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "🍏 Checking macOS system requirements..."
+    MEMORY_GB=$(sysctl -n hw.memsize | awk '{print int($1/1024/1024/1024)}')
+    CPU_CORES=$(sysctl -n hw.ncpu)
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "🐧 Checking Linux system requirements..."
+    if [ -f /proc/meminfo ]; then
+        MEMORY_GB=$(grep MemTotal /proc/meminfo | awk '{print int($2/1024/1024)}')
+    else
+        echo "⚠️ Could not read /proc/meminfo to determine system memory."
+    fi
+    if command -v nproc &> /dev/null; then
+        CPU_CORES=$(nproc)
+    else
+        echo "⚠️ nproc command not found, defaulting to 1 CPU core for estimates."
+    fi
+else
+    echo "⚠️ Unsupported OS ($OSTYPE) for detailed system checks. Proceeding with default assumptions (0GB RAM, 1 CPU core)."
+fi
+
 if [ "$MEMORY_GB" -lt 16 ]; then
-    echo "⚠️  Warning: Only ${MEMORY_GB}GB RAM detected. 16GB+ recommended for building."
+    if [ "$MEMORY_GB" -gt 0 ]; then # Only warn if we got a valid reading
+        echo "⚠️  Warning: Only ${MEMORY_GB}GB RAM detected. 16GB+ recommended for building."
+    else
+        echo "⚠️  Warning: Could not determine system RAM. 16GB+ recommended for building."
+    fi
     read -p "Continue anyway? (y/N): " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -38,8 +70,8 @@ if [ "$MEMORY_GB" -lt 16 ]; then
     fi
 fi
 
-# Check available disk space
-AVAILABLE_SPACE=$(df -h . | awk 'NR==2 {print $4}' | sed 's/G//')
+# Check available disk space (seems OS-agnostic enough)
+AVAILABLE_SPACE=$(df -h . | awk 'NR==2 {print $4}' | sed 's/[^0-9.]//g') # More robust sed
 if [ "$AVAILABLE_SPACE" -lt 50 ]; then
     echo "⚠️  Warning: Less than 50GB available. Build requires ~50GB additional space."
     read -p "Continue anyway? (y/N): " -n 1 -r
@@ -63,7 +95,7 @@ echo "📋 Build configuration:"
 gn args out/HenSurf --list --short
 
 # Estimate build time
-CPU_CORES=$(sysctl -n hw.ncpu)
+# CPU_CORES is now determined OS-specifically above
 ESTIMATED_HOURS=$((8 / CPU_CORES))
 if [ "$ESTIMATED_HOURS" -lt 1 ]; then
     ESTIMATED_HOURS=1
@@ -96,46 +128,72 @@ fi
 echo "🔨 Building additional components..."
 autoninja -C out/HenSurf chromedriver 2>&1 | tee -a out/HenSurf/build.log
 
-# Create application bundle for macOS
-echo "📦 Creating macOS application bundle..."
-if [ -d "out/HenSurf/HenSurf.app" ]; then
-    rm -rf out/HenSurf/HenSurf.app
-fi
+# Create application bundle for macOS (and build macOS installer)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "📦 Creating macOS application bundle..."
+    if [ -d "out/HenSurf/HenSurf.app" ]; then
+        rm -rf out/HenSurf/HenSurf.app
+    fi
 
-# Copy and rename the Chrome app bundle
-cp -R out/HenSurf/Chromium.app out/HenSurf/HenSurf.app 2>/dev/null || \
-cp -R out/HenSurf/Google\ Chrome.app out/HenSurf/HenSurf.app 2>/dev/null || \
-cp -R out/HenSurf/Chrome.app out/HenSurf/HenSurf.app 2>/dev/null || true
+    # Copy and rename the Chrome app bundle
+    # Try common names for the output app bundle from Chromium build
+    CHROME_APP_NAMES=( "Chromium.app" "Google Chrome.app" "Chrome.app" )
+    APP_COPIED=false
+    for app_name in "${CHROME_APP_NAMES[@]}"; do
+        if [ -d "out/HenSurf/${app_name}" ]; then
+            echo "Found ${app_name}, copying to HenSurf.app..."
+            cp -R "out/HenSurf/${app_name}" "out/HenSurf/HenSurf.app"
+            APP_COPIED=true
+            break
+        fi
+    done
 
-if [ -d "out/HenSurf/HenSurf.app" ]; then
-    # Update Info.plist
-    /usr/libexec/PlistBuddy -c "Set :CFBundleName HenSurf" out/HenSurf/HenSurf.app/Contents/Info.plist 2>/dev/null || true
-    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName HenSurf Browser" out/HenSurf/HenSurf.app/Contents/Info.plist 2>/dev/null || true
-    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.hensurf.browser" out/HenSurf/HenSurf.app/Contents/Info.plist 2>/dev/null || true
-    
-    echo "✅ HenSurf.app created successfully!"
-else
-    echo "⚠️  Could not create app bundle, but binary should be available"
-fi
+    if [ "$APP_COPIED" = true ] && [ -d "out/HenSurf/HenSurf.app" ]; then
+        # Update Info.plist
+        PLIST_BUDDY="/usr/libexec/PlistBuddy"
+        INFO_PLIST="out/HenSurf/HenSurf.app/Contents/Info.plist"
+        if [ -f "$PLIST_BUDDY" ] && [ -f "$INFO_PLIST" ]; then
+            "$PLIST_BUDDY" -c "Set :CFBundleName HenSurf" "$INFO_PLIST" 2>/dev/null || echo "Warning: Failed to set CFBundleName"
+            "$PLIST_BUDDY" -c "Set :CFBundleDisplayName HenSurf Browser" "$INFO_PLIST" 2>/dev/null || echo "Warning: Failed to set CFBundleDisplayName"
+            "$PLIST_BUDDY" -c "Set :CFBundleIdentifier com.hensurf.browser" "$INFO_PLIST" 2>/dev/null || echo "Warning: Failed to set CFBundleIdentifier"
+            echo "✅ HenSurf.app created and configured successfully!"
+        else
+            echo "⚠️  PlistBuddy or Info.plist not found. Cannot customize app bundle."
+        fi
+    else
+        echo "⚠️  Could not find a base Chrome app bundle (Chromium.app, Google Chrome.app, or Chrome.app) in out/HenSurf/ to create HenSurf.app."
+        echo "   The raw 'chrome' binary should still be available."
+    fi
 
-# Build installer (optional)
-echo "📦 Building installer..."
-autoninja -C out/HenSurf chrome/installer/mac 2>&1 | tee -a out/HenSurf/build.log || true
+    # Build macOS installer (optional)
+    echo "📦 Building macOS installer (dmg)..."
+    autoninja -C out/HenSurf mini_installer 2>&1 | tee -a out/HenSurf/build.log || echo "ℹ️  macOS installer build step finished (may have warnings or be skipped)."
+
+fi # End of macOS specific bundling
 
 echo ""
 echo "🎉 HenSurf build completed successfully!"
 echo ""
-echo "📍 Build artifacts location:"
-echo "   Binary: chromium/src/out/HenSurf/chrome"
-if [ -d "out/HenSurf/HenSurf.app" ]; then
-    echo "   App Bundle: chromium/src/out/HenSurf/HenSurf.app"
+echo "📍 Build artifacts location (relative to chromium/src):"
+echo "   Main executable: out/HenSurf/chrome"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [ -d "out/HenSurf/HenSurf.app" ]; then
+        echo "   macOS App Bundle: out/HenSurf/HenSurf.app"
+    fi
+    if [ -f "out/HenSurf/HenSurf.dmg" ]; then # Assuming mini_installer produces HenSurf.dmg
+        echo "   macOS Installer:  out/HenSurf/HenSurf.dmg"
+    fi
 fi
-echo "   Build log: chromium/src/out/HenSurf/build.log"
+echo "   Build log: out/HenSurf/build.log"
 echo ""
-echo "🚀 To run HenSurf:"
-if [ -d "out/HenSurf/HenSurf.app" ]; then
-    echo "   open out/HenSurf/HenSurf.app"
-else
+echo "🚀 To run HenSurf (from chromium/src directory):"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [ -d "out/HenSurf/HenSurf.app" ]; then
+        echo "   open out/HenSurf/HenSurf.app"
+    else
+        echo "   ./out/HenSurf/chrome  (App bundle creation failed or was skipped)"
+    fi
+else # For Linux and other OSes
     echo "   ./out/HenSurf/chrome"
 fi
 echo ""

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -7,67 +7,131 @@ set -e
 
 echo "🚀 Installing HenSurf build dependencies..."
 
-# Check if running on macOS
-if [[ "$OSTYPE" != "darwin"* ]]; then
-    echo "❌ This script is designed for macOS only."
+# OS detection
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "🍎 Detected macOS"
+
+    # Check if Homebrew is installed
+    if ! command -v brew &> /dev/null; then
+        echo "📦 Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    else
+        echo "✅ Homebrew already installed"
+    fi
+
+    # Update Homebrew
+    echo "🔄 Updating Homebrew..."
+    brew update
+
+    # Install required packages for macOS
+    # Common deps: python3, git, ninja, pkg-config
+    echo "📦 Installing required packages for macOS (python3, git, ninja, pkg-config)..."
+    brew install python3 git ninja pkg-config
+
+    # Install Xcode Command Line Tools if not present
+    if ! xcode-select -p &> /dev/null; then
+        echo "🔧 Installing Xcode Command Line Tools..."
+        xcode-select --install
+        echo "⏳ Please complete the Xcode Command Line Tools installation GUI."
+        echo "   After installation, re-run this script."
+        read -p "Press [Enter] to continue after Xcode Command Line Tools are installed, or Ctrl+C to exit and re-run later."
+        if ! xcode-select -p &> /dev/null; then
+            echo "❌ Xcode Command Line Tools still not found. Please re-run the script after installation."
+            exit 1
+        fi
+        echo "✅ Xcode Command Line Tools installation detected."
+    else
+        echo "✅ Xcode Command Line Tools already installed"
+    fi
+
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "🐧 Detected Linux"
+    if command -v apt-get &> /dev/null; then
+        echo "Distro: Debian/Ubuntu (apt package manager found)"
+        echo "📦 Installing dependencies for Debian/Ubuntu..."
+        sudo apt-get update
+        sudo apt-get install -y python3 git ninja-build pkg-config build-essential libgtk-3-dev libnss3-dev libasound2-dev libcups2-dev libxtst-dev libxss1 libatk1.0-dev libatk-bridge2.0-dev libdrm-dev libgbm-dev libx11-xcb-dev uuid-dev
+    elif command -v dnf &> /dev/null; then
+        echo "Distro: Fedora (dnf package manager found)"
+        echo "📦 Installing dependencies for Fedora..."
+        sudo dnf install -y python3 git ninja-build pkgconf-pkg-config gcc-c++ gtk3-devel nss-devel alsa-lib-devel cups-devel libXtst-devel libXScrnSaver-devel atk-devel at-spi2-atk-devel libdrm-devel libgbm-devel libX11-xcb-devel libuuid-devel
+    elif command -v pacman &> /dev/null; then
+        echo "Distro: Arch Linux (pacman package manager found)"
+        echo "📦 Installing dependencies for Arch Linux..."
+        sudo pacman -Syu --noconfirm --needed base-devel python git ninja pkgconf gtk3 nss alsa-lib cups libxtst libxscrnsaver libatk at-spi2-atk libdrm libgbm libx11 libxcb util-linux
+    else
+        echo "❌ Unsupported Linux distribution or package manager not found."
+        echo "Please install the following dependencies manually:"
+        echo "  python3, git, ninja-build (or ninja), pkg-config, gcc/g++ (build-essential),"
+        echo "  libgtk-3-dev, libnss3-dev, libasound2-dev, libcups2-dev, libxtst-dev,"
+        echo "  libxss1 (or libxscrnsaver), libatk1.0-dev, libatk-bridge2.0-dev, libdrm-dev, libgbm-dev,"
+        echo "  libx11-xcb-dev, uuid-dev (or libuuid-devel or util-linux for uuidgen)"
+        exit 1
+    fi
+else
+    echo "❌ Unsupported operating system: $OSTYPE"
     exit 1
 fi
 
-# Check if Homebrew is installed
-if ! command -v brew &> /dev/null; then
-    echo "📦 Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Check Python version (common logic for macOS and Linux)
+echo "🐍 Checking Python version..."
+PYTHON_CMD=""
+if command -v python3 &> /dev/null; then
+    PYTHON_CMD="python3"
+elif command -v python &> /dev/null; then
+    PYTHON_CMD="python"
 else
-    echo "✅ Homebrew already installed"
-fi
-
-# Update Homebrew
-echo "🔄 Updating Homebrew..."
-brew update
-
-# Install required packages
-echo "📦 Installing required packages..."
-brew install python3 git ninja
-
-# Install Xcode Command Line Tools if not present
-if ! xcode-select -p &> /dev/null; then
-    echo "🔧 Installing Xcode Command Line Tools..."
-    xcode-select --install
-    echo "⚠️  Please complete the Xcode Command Line Tools installation and run this script again."
-    exit 1
-else
-    echo "✅ Xcode Command Line Tools already installed"
-fi
-
-# Check Python version
-PYTHON_VERSION=$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2)
-REQUIRED_VERSION="3.8"
-
-if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$PYTHON_VERSION" | sort -V | head -n1)" = "$REQUIRED_VERSION" ]; then
-    echo "✅ Python $PYTHON_VERSION is compatible"
-else
-    echo "❌ Python $PYTHON_VERSION is too old. Please install Python 3.8 or newer."
+    echo "❌ Python not found. Please install Python 3.8 or newer."
     exit 1
 fi
 
-# Create depot_tools directory if it doesn't exist
-if [ ! -d "../depot_tools" ]; then
-    echo "📦 Downloading depot_tools..."
-    cd ..
+PYTHON_VERSION_FULL=$($PYTHON_CMD --version 2>&1)
+PYTHON_VERSION=$(echo "$PYTHON_VERSION_FULL" | cut -d' ' -f2 | cut -d'.' -f1,2)
+REQUIRED_MAJOR=3
+REQUIRED_MINOR=8
+
+CURRENT_MAJOR=$(echo "$PYTHON_VERSION" | cut -d'.' -f1)
+CURRENT_MINOR=$(echo "$PYTHON_VERSION" | cut -d'.' -f2)
+
+if [ "$CURRENT_MAJOR" -lt "$REQUIRED_MAJOR" ] || { [ "$CURRENT_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$CURRENT_MINOR" -lt "$REQUIRED_MINOR" ]; }; then
+    echo "❌ Python version $PYTHON_VERSION ($PYTHON_VERSION_FULL) is too old."
+    echo "   Please install Python $REQUIRED_MAJOR.$REQUIRED_MINOR or newer."
+    echo "   Found at: $($PYTHON_CMD -c 'import sys; print(sys.executable)')"
+    exit 1
+else
+    echo "✅ Python $PYTHON_VERSION ($PYTHON_VERSION_FULL) is compatible (found at $($PYTHON_CMD -c 'import sys; print(sys.executable)'))"
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." &>/dev/null && pwd)
+PARENT_OF_PROJECT_ROOT=$(cd "$PROJECT_ROOT/.." &>/dev/null && pwd)
+DEPOT_TOOLS_DIR="$PARENT_OF_PROJECT_ROOT/depot_tools"
+
+if [ ! -d "$DEPOT_TOOLS_DIR" ]; then
+    echo "📦 Downloading depot_tools into $PARENT_OF_PROJECT_ROOT..."
+
+    ORIGINAL_PWD=$(pwd)
+    echo "Changing directory to $PARENT_OF_PROJECT_ROOT for cloning depot_tools."
+    cd "$PARENT_OF_PROJECT_ROOT"
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-    cd HenSurf
+    echo "Changing directory back to $ORIGINAL_PWD."
+    cd "$ORIGINAL_PWD"
 else
-    echo "✅ depot_tools already exists"
+    echo "✅ depot_tools already exists at $DEPOT_TOOLS_DIR"
 fi
 
-# Add depot_tools to PATH for this session
-export PATH="$PWD/../depot_tools:$PATH"
+export PATH="$DEPOT_TOOLS_DIR:$PATH"
+echo "🔧 Added depot_tools to PATH for this session: $DEPOT_TOOLS_DIR"
+echo "   (Note: This PATH change is only for the current terminal session.)"
 
-echo "✅ All dependencies installed successfully!"
+echo "✅ All core dependencies installed and depot_tools configured for this session!"
 echo ""
 echo "Next steps:"
-echo "1. Run ./scripts/fetch-chromium.sh to download Chromium source"
-echo "2. Run ./scripts/apply-patches.sh to apply HenSurf customizations"
-echo "3. Run ./scripts/build.sh to build HenSurf"
+echo "1. IMPORTANT: Add depot_tools to your shell's startup file (e.g., ~/.bashrc, ~/.zshrc) if you haven't already:"
+echo "   echo 'export PATH=\"$DEPOT_TOOLS_DIR:\$PATH\"' >> ~/.your_shell_rc_file"
+echo "   Then, source the file (e.g., source ~/.bashrc) or open a new terminal."
+echo "2. Run ./scripts/fetch-chromium.sh to download Chromium source (will use depot_tools from PATH)."
+echo "3. Run ./scripts/apply-patches.sh to apply HenSurf customizations."
+echo "4. Run ./scripts/build.sh to build HenSurf."
 echo ""
-echo "⚠️  Note: The full build process requires ~100GB of disk space and several hours."
+echo "⚠️  Note: The full Chromium build process requires significant disk space (~100GB) and can take several hours."


### PR DESCRIPTION
This commit introduces modifications to the build and dependency installation scripts to enable building HenSurf on Linux platforms.

Key changes:

- `scripts/install-deps.sh`:
  - Added detection for Linux (Debian/Ubuntu, Fedora, Arch).
  - Implemented package installation using `apt`, `dnf`, and `pacman` for common Chromium build dependencies.
  - Ensured Python version checks and `depot_tools` installation are OS-agnostic.
  - Preserved existing macOS dependency installation logic.

- `scripts/build.sh`:
  - Updated system requirement checks (RAM, CPU cores) to use Linux-native commands (`/proc/meminfo`, `nproc`).
  - Made macOS-specific application bundling (creating `.app`, `Info.plist` modification) conditional to `OSTYPE=darwin*`.
  - Corrected the `depot_tools` PATH to reflect its location as installed by `install-deps.sh` (i.e., `../../depot_tools` when CWD is `chromium/src`).
  - Provided OS-specific instructions for running the built browser.

These changes allow you to install dependencies, build the HenSurf browser, and launch it on supported Linux distributions. Further testing on various Linux distributions is recommended.