### PR TITLE
Add initial support for building HenSurf on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,102 @@ HenSurf is a custom build of Chromium that removes:
 - ✅ Fast and lightweight
 - ✅ Open source
 
-## Build Requirements
+## Build Requirements (macOS / Linux)
 
-- macOS 10.15 or later
-- Xcode Command Line Tools
-- Python 3.8+
+- macOS 10.15+ or a modern Linux distribution (e.g., Ubuntu, Fedora, Arch)
+- Xcode Command Line Tools (for macOS) or `build-essential` package (for Linux, provides `gcc`, `g++`, `make`)
+- Python 3.8+ (must be accessible as `python3` or `python`)
 - Git
-- At least 100GB free disk space
-- 16GB+ RAM recommended
+- At least 150GB free disk space (Chromium source code and build artifacts are very large).
+- 16GB+ RAM recommended (32GB+ for faster builds).
+
+For Windows, please see the "Building on Windows" section below.
+
+## Building on Windows
+
+Building Chromium (and thus HenSurf) on Windows has specific prerequisites and requires using Git Bash for the provided scripts.
+
+**Prerequisites:**
+
+*   **Git for Windows:** Essential for cloning the repository and running the build scripts.
+    *   **Download:** [https://git-scm.com/download/win](https://git-scm.com/download/win)
+    *   **Important:** You **must** use **Git Bash** (which comes with Git for Windows) to run all `.sh` scripts.
+*   **Python:** Version 3.8+ is required by Chromium's build tools.
+    *   **Download:** [https://www.python.org/downloads/windows/](https://www.python.org/downloads/windows/)
+    *   Ensure you add Python to your system PATH during installation.
+*   **Ninja Build Tool:** A small build system used by Chromium.
+    *   **Download:** [https://github.com/ninja-build/ninja/releases](https://github.com/ninja-build/ninja/releases)
+    *   Download `ninja.exe` from the latest Windows release.
+    *   Create a directory (e.g., `C:\Ninja`) and place `ninja.exe` there.
+    *   Add this directory to your system PATH.
+*   **Visual Studio C++ Build Tools:** Crucial for compiling C++ code on Windows.
+    *   **Download:** [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/) (Community edition is free and sufficient).
+    *   **Required Workload:** During installation, you **must** select the "Desktop development with C++" workload.
+    *   HenSurf typically builds with VS 2019 (e.g., v16.11.14+) or VS 2022. `depot_tools` (installed by `install-deps.sh`) may try to manage this if specific environment variables are set (see `install-deps.sh` output).
+*   **(Optional) Chocolatey for Prerequisite Installation:**
+    *   If you use the [Chocolatey](https://chocolatey.org/) package manager, you can install most prerequisites with a command like (run in an **Administrator** PowerShell or CMD prompt):
+        ```powershell
+        choco install python git ninja visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended"
+        # Note: Verify the exact package names and parameters if issues arise.
+        ```
+    *   Close and reopen Git Bash after installing tools to ensure PATH changes take effect.
+*   **Disk Space:** At least **150GB** of free disk space on an NTFS-formatted drive.
+*   **RAM:** **16GB+** highly recommended (32GB+ for a significantly better experience).
+
+**Build Steps:**
+
+1.  **Open Git Bash:** All subsequent commands should be run in a Git Bash terminal.
+2.  **Clone HenSurf Repository:**
+    ```bash
+    # Replace with the actual repository URL if different
+    git clone https://github.com/your-username/hensurf.git
+    cd hensurf
+    ```
+3.  **Install Dependencies & depot_tools:**
+    ```bash
+    ./scripts/install-deps.sh
+    ```
+    This script will check for Python, Git, and Ninja. It will also download `depot_tools` (Chromium's bootstrap toolset). Pay close attention to its output, especially regarding Visual Studio and adding `depot_tools` to your PATH permanently.
+4.  **Fetch Chromium Source Code:**
+    ```bash
+    ./scripts/fetch-chromium.sh
+    ```
+    This is a lengthy process that downloads the entire Chromium source code. It can take 30 minutes to several hours depending on your internet connection and consume ~100GB of disk space.
+5.  **Apply HenSurf Customizations:**
+    ```bash
+    ./scripts/apply-patches.sh
+    ```
+    This script applies HenSurf's modifications to the Chromium source.
+6.  **Build HenSurf:**
+    ```bash
+    ./scripts/build.sh
+    ```
+    This compiles the browser. This is also a very lengthy process (can take multiple hours depending on your CPU and RAM).
+
+**Running HenSurf on Windows:**
+
+*   After a successful build, the main executable will be located at:
+    `chromium/src/out/HenSurf/chrome.exe`
+*   An installer might also be created (the name can vary):
+    `chromium/src/out/HenSurf/mini_installer.exe` or `chromium/src/out/HenSurf/setup.exe`
+
+**Important Notes for Windows Builds:**
+
+*   **Git Bash:** All `.sh` scripts **must** be run from a Git Bash terminal. Do not use CMD or PowerShell for these scripts.
+*   **Resource Intensive:** Building Chromium is extremely demanding on CPU, RAM, and disk I/O.
+*   **Time Consuming:** Expect the entire process (fetch + build) to take several hours, even on powerful hardware.
+*   **`depot_tools` PATH:** Ensure `depot_tools` is correctly added to your Windows PATH environment variable (as instructed by `install-deps.sh`) for subsequent terminal sessions.
+*   **Long File Paths:** Ensure your repository is cloned to a path with a short overall length (e.g., `C:\dev\hensurf`) to avoid issues with Windows' maximum path length limits during the build.
 
 ## Quick Start
+
+The following steps are a general guide. Windows users, please refer to the "Building on Windows" section above for specific prerequisites and detailed environment setup.
 
 1. Install dependencies:
    ```bash
    ./scripts/install-deps.sh
    ```
+   This script will guide you through initial setup, including `depot_tools`.
 
 2. Download Chromium source:
    ```bash
@@ -103,13 +184,13 @@ HenSurf uses custom build configurations to remove unwanted features:
 
 If you encounter issues while building or running HenSurf, here are some common troubleshooting steps:
 
-*   **Check Dependencies**: Ensure all build requirements listed in the "Build Requirements" section are installed correctly. You can try re-running the dependency installation script:
+*   **Check Dependencies**: Ensure all build requirements (macOS/Linux or Windows specific) are installed correctly. You can try re-running the dependency installation script:
     ```bash
     ./scripts/install-deps.sh
     ```
-*   **Clean Build Directory**: Sometimes, previous build artifacts can cause issues. Clean your build directory and try again. *Note: Specific commands to clean the build directory depend on the Chromium build process and might involve deleting the `out` directory or similar. Refer to Chromium build documentation if unsure.*
-*   **Check Logs**: Build and runtime logs can provide valuable information about what went wrong. Look for error messages in the console output. Chromium build logs are typically found in the build output directory (e.g., `out/Release/build.log`).
-*   **Disk Space**: Ensure you have sufficient free disk space (at least 100GB recommended) as Chromium's source and build files are very large.
+*   **Clean Build Directory**: Sometimes, previous build artifacts can cause issues. Clean your build directory (typically `chromium/src/out/HenSurf`) and try again.
+*   **Check Logs**: Build and runtime logs can provide valuable information about what went wrong. Look for error messages in the console output. HenSurf build logs are typically found in `chromium/src/out/HenSurf/build.log`.
+*   **Disk Space**: Ensure you have sufficient free disk space (at least 150GB recommended) as Chromium's source and build files are very large.
 *   **Memory Usage**: Building Chromium is memory-intensive. If the build fails with errors related to memory, ensure you have enough RAM (16GB+ recommended) and close other memory-heavy applications.
 *   **Consult Chromium Documentation**: For issues related to the underlying Chromium build system, the official [Chromium build documentation](https://www.chromium.org/developers/how-tos/get-the-code/) can be a helpful resource.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,16 +19,32 @@ if [ ! -f "chromium/src/out/HenSurf/args.gn" ]; then
     exit 1
 fi
 
-# Add depot_tools to PATH
-# Corrected path: install-deps.sh places depot_tools alongside the project root (e.g. ../depot_tools if project is HenSurf)
-# This script cds into chromium/src, so from there, depot_tools is ../../depot_tools
+# Determine script and project paths
+SCRIPT_DIR_BUILD=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PROJECT_ROOT_BUILD=$(cd "$SCRIPT_DIR_BUILD/.." &>/dev/null && pwd)
 
-cd chromium/src
+# Corrected depot_tools path logic:
+# Assuming depot_tools is ALONGSIDE HenSurf project directory (e.g. ../depot_tools)
+DEPOT_TOOLS_DIR_ABS=$(cd "$PROJECT_ROOT_BUILD/../depot_tools" &>/dev/null && pwd)
 
-# IMPORTANT: Set path to depot_tools, assuming it's two levels up from chromium/src
-# e.g. if project is /path/to/HenSurf, depot_tools is /path/to/depot_tools
-# and current dir is /path/to/HenSurf/chromium/src
-export PATH="$PWD/../../depot_tools:$PATH"
+if [ ! -d "$DEPOT_TOOLS_DIR_ABS" ]; then
+    echo "❌ depot_tools not found at expected absolute location: $PROJECT_ROOT_BUILD/../depot_tools"
+    echo "   This path was derived from this script's location: $SCRIPT_DIR_BUILD"
+    echo "   Please ensure depot_tools is cloned adjacent to the HenSurf project directory."
+    exit 1
+fi
+export PATH="$DEPOT_TOOLS_DIR_ABS:$PATH"
+echo "🔧 Added depot_tools to PATH: $DEPOT_TOOLS_DIR_ABS"
+
+# Navigate to the chromium source directory
+CHROMIUM_SRC_DIR="$PROJECT_ROOT_BUILD/chromium/src"
+if [ ! -d "$CHROMIUM_SRC_DIR" ]; then
+    echo "❌ Chromium source directory not found at $CHROMIUM_SRC_DIR"
+    echo "   Please ensure you have run ./scripts/fetch-chromium.sh successfully."
+    exit 1
+fi
+cd "$CHROMIUM_SRC_DIR"
+echo "Current directory: $(pwd)"
 
 
 # Check system requirements
@@ -45,35 +61,107 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     echo "🐧 Checking Linux system requirements..."
     if [ -f /proc/meminfo ]; then
         MEMORY_GB=$(grep MemTotal /proc/meminfo | awk '{print int($2/1024/1024)}')
-    else
-        echo "⚠️ Could not read /proc/meminfo to determine system memory."
+    else # Fallback for systems without /proc/meminfo but might have 'free'
+        MEMORY_KB=$(free | grep Mem: | awk '{print $2}')
+        if [[ "$MEMORY_KB" =~ ^[0-9]+$ ]]; then
+            MEMORY_GB=$(awk -v memkb="$MEMORY_KB" 'BEGIN { printf "%.0f", memkb / 1024 / 1024 }')
+        else
+            echo "⚠️ Could not determine system memory from /proc/meminfo or free."
+        fi
     fi
     if command -v nproc &> /dev/null; then
         CPU_CORES=$(nproc)
     else
-        echo "⚠️ nproc command not found, defaulting to 1 CPU core for estimates."
+        CPU_CORES=$(grep -c ^processor /proc/cpuinfo || echo 1) # Fallback for CPU cores
+        echo "⚠️ nproc command not found, using /proc/cpuinfo or defaulting to $CPU_CORES CPU core(s) for estimates."
     fi
+    echo "   Detected RAM: ${MEMORY_GB}GB, CPU Cores: $CPU_CORES"
+elif [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]]; then
+    echo "💻 Checking Windows system requirements..."
+    if ! command -v wmic &> /dev/null; then
+        echo "⚠️ 'wmic' command not found. Cannot check system requirements accurately."
+        MEMORY_GB=0 # Explicitly set to 0 if wmic not found
+        CPU_CORES=1 # Default
+    else
+        TOTAL_MEM_KB_STR=$(wmic OS get TotalVisibleMemorySize /value | tr -d '\r' | grep TotalVisibleMemorySize | cut -d'=' -f2)
+        if [[ -n "$TOTAL_MEM_KB_STR" && "$TOTAL_MEM_KB_STR" =~ ^[0-9]+$ ]]; then
+            MEMORY_GB=$(awk -v memkb="$TOTAL_MEM_KB_STR" 'BEGIN { printf "%.0f", memkb / 1024 / 1024 }')
+        else
+            echo "⚠️ Could not determine TotalVisibleMemorySize using wmic. Output: '$TOTAL_MEM_KB_STR'"
+            MEMORY_GB=0
+        fi
+
+        CPU_CORES_STR=$(wmic cpu get NumberOfLogicalProcessors /value | tr -d '\r' | grep NumberOfLogicalProcessors | cut -d'=' -f2)
+        if [[ -n "$CPU_CORES_STR" && "$CPU_CORES_STR" =~ ^[0-9]+$ ]]; then
+            CPU_CORES=$CPU_CORES_STR
+        else
+            echo "⚠️ Could not determine NumberOfLogicalProcessors using wmic. Output: '$CPU_CORES_STR'"
+            CPU_CORES=1 # Default if detection fails
+        fi
+    fi
+    echo "   Detected RAM: ${MEMORY_GB}GB, CPU Cores: $CPU_CORES"
 else
     echo "⚠️ Unsupported OS ($OSTYPE) for detailed system checks. Proceeding with default assumptions (0GB RAM, 1 CPU core)."
+    MEMORY_GB=0 # Ensure it's 0 if OS is unsupported
+    CPU_CORES=1
 fi
 
-if [ "$MEMORY_GB" -lt 16 ]; then
-    if [ "$MEMORY_GB" -gt 0 ]; then # Only warn if we got a valid reading
-        echo "⚠️  Warning: Only ${MEMORY_GB}GB RAM detected. 16GB+ recommended for building."
+MIN_RAM_GB=16
+if [ "$MEMORY_GB" -lt "$MIN_RAM_GB" ]; then
+    if [ "$MEMORY_GB" -gt 0 ]; then # Only warn if we got a valid reading and it's below threshold
+        echo "⚠️  Warning: Only ${MEMORY_GB}GB RAM detected. ${MIN_RAM_GB}GB+ recommended for building Chromium."
+    elif [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]] || [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
+         # If OS is known but RAM is 0, it means detection failed.
+        echo "⚠️  Warning: Could not reliably determine system RAM. ${MIN_RAM_GB}GB+ recommended for building Chromium."
+    fi
+    # For unknown OS, the warning about unsupported OS for checks has already been printed.
+    # Only prompt if we are on a known OS or if RAM detection gave a value (even if 0 due to error).
+    if [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]] || \
+       [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "linux-gnu"* ]] || [ "$MEMORY_GB" -gt 0 ]; then
+        read -p "Continue anyway? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    fi
+fi
+
+# Check available disk space
+MIN_BUILD_DISK_SPACE_GB=50
+AVAILABLE_SPACE_GB=0 # Default to 0
+
+if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    AVAILABLE_SPACE_GB=$(df -BG . | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d '[:space:]')
+    echo "Disk space check (Linux/macOS): ${AVAILABLE_SPACE_GB}GB available in $(pwd)."
+elif [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]]; then
+    echo "💻 Checking disk space on Windows in $(pwd)..."
+    CURRENT_DRIVE_LETTER_BUILD=$(pwd -W | cut -d':' -f1)
+    if ! command -v wmic &> /dev/null; then
+        echo "⚠️ 'wmic' command not found. Cannot check disk space accurately on Windows."
+        AVAILABLE_SPACE_GB=0
     else
-        echo "⚠️  Warning: Could not determine system RAM. 16GB+ recommended for building."
+        AVAILABLE_BYTES_STR_BUILD=$(wmic logicaldisk where "DeviceID='${CURRENT_DRIVE_LETTER_BUILD}:'" get FreeSpace /value | tr -d '\r' | grep FreeSpace | cut -d'=' -f2)
+        if [[ -z "$AVAILABLE_BYTES_STR_BUILD" || ! "$AVAILABLE_BYTES_STR_BUILD" =~ ^[0-9]+$ ]]; then
+             echo "⚠️ Could not determine free space using wmic for drive ${CURRENT_DRIVE_LETTER_BUILD}: (Output: '$AVAILABLE_BYTES_STR_BUILD')."
+             AVAILABLE_SPACE_GB=0
+        else
+            AVAILABLE_SPACE_GB=$(awk -v bytes="$AVAILABLE_BYTES_STR_BUILD" 'BEGIN { printf "%.0f", bytes / 1024 / 1024 / 1024 }')
+        fi
     fi
-    read -p "Continue anyway? (y/N): " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
-    fi
+    echo "Drive ${CURRENT_DRIVE_LETTER_BUILD}: has approximately ${AVAILABLE_SPACE_GB}GB free."
+else
+    echo "⚠️ Unsupported OS for disk space check: $OSTYPE. Assuming ${MIN_BUILD_DISK_SPACE_GB}GB available."
+    AVAILABLE_SPACE_GB=${MIN_BUILD_DISK_SPACE_GB}
 fi
 
-# Check available disk space (seems OS-agnostic enough)
-AVAILABLE_SPACE=$(df -h . | awk 'NR==2 {print $4}' | sed 's/[^0-9.]//g') # More robust sed
-if [ "$AVAILABLE_SPACE" -lt 50 ]; then
-    echo "⚠️  Warning: Less than 50GB available. Build requires ~50GB additional space."
+# Ensure AVAILABLE_SPACE_GB is a number, default to 0 if not
+if ! [[ "$AVAILABLE_SPACE_GB" =~ ^[0-9]+$ ]]; then
+    echo "⚠️ Could not reliably determine available disk space in $(pwd). Detected: '$AVAILABLE_SPACE_GB'."
+    AVAILABLE_SPACE_GB=0
+fi
+
+if [ "$AVAILABLE_SPACE_GB" -lt "$MIN_BUILD_DISK_SPACE_GB" ]; then
+    echo "⚠️  Warning: Only ${AVAILABLE_SPACE_GB}GB detected as available in $(pwd). Build output requires ~${MIN_BUILD_DISK_SPACE_GB}GB."
     read -p "Continue anyway? (y/N): " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -167,32 +255,68 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
     # Build macOS installer (optional)
     echo "📦 Building macOS installer (dmg)..."
-    autoninja -C out/HenSurf mini_installer 2>&1 | tee -a out/HenSurf/build.log || echo "ℹ️  macOS installer build step finished (may have warnings or be skipped)."
+    autoninja -C out/HenSurf mini_installer 2>&1 | tee -a out/HenSurf/build.log || echo "ℹ️  macOS installer build step finished (may have warnings or be skipped if not configured)."
 
-fi # End of macOS specific bundling
+elif [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]]; then
+    echo "📦 Building Windows installer (mini_installer)..."
+    autoninja -C out/HenSurf mini_installer 2>&1 | tee -a out/HenSurf/build.log || echo "ℹ️  Windows installer build step finished (may have warnings or be skipped if not configured)."
+    # Check for common installer names
+    if [ -f "out/HenSurf/mini_installer.exe" ]; then
+        echo "✅ Windows mini_installer.exe found."
+    elif [ -f "out/HenSurf/setup.exe" ]; then
+        echo "✅ Windows setup.exe found."
+    else
+        echo "⚠️  Windows installer (mini_installer.exe or setup.exe) not found in out/HenSurf/. Build might have skipped it or an issue occurred."
+    fi
+fi # End of OS specific bundling
 
 echo ""
 echo "🎉 HenSurf build completed successfully!"
 echo ""
-echo "📍 Build artifacts location (relative to chromium/src):"
-echo "   Main executable: out/HenSurf/chrome"
+echo "📍 Build artifacts location (relative to $CHROMIUM_SRC_DIR):"
+echo "   Main executable: out/HenSurf/chrome${EXE_SUFFIX}" # EXE_SUFFIX will be .exe on windows, empty otherwise
 if [[ "$OSTYPE" == "darwin"* ]]; then
     if [ -d "out/HenSurf/HenSurf.app" ]; then
         echo "   macOS App Bundle: out/HenSurf/HenSurf.app"
     fi
-    if [ -f "out/HenSurf/HenSurf.dmg" ]; then # Assuming mini_installer produces HenSurf.dmg
-        echo "   macOS Installer:  out/HenSurf/HenSurf.dmg"
+    # Attempt to find the actual DMG name as mini_installer might produce versioned names
+    DMG_FILE=$(ls out/HenSurf/*.dmg 2>/dev/null | head -n 1)
+    if [ -f "$DMG_FILE" ]; then
+        echo "   macOS Installer:  $(basename "$DMG_FILE") (in out/HenSurf/)"
+    elif [ -f "out/HenSurf/HenSurf.dmg" ]; then # Fallback to generic name
+         echo "   macOS Installer:  HenSurf.dmg (in out/HenSurf/)"
+    fi
+elif [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]]; then
+    if [ -f "out/HenSurf/mini_installer.exe" ]; then
+        echo "   Windows Installer: out/HenSurf/mini_installer.exe"
+    elif [ -f "out/HenSurf/setup.exe" ]; then # Common alternative name
+        echo "   Windows Installer: out/HenSurf/setup.exe"
+    else
+        # Check for versioned installer name like chrome_installer.exe, etc.
+        WIN_INSTALLER_FILE=$(ls out/HenSurf/*installer.exe 2>/dev/null | head -n 1)
+        if [ -f "$WIN_INSTALLER_FILE" ]; then
+             echo "   Windows Installer: $(basename "$WIN_INSTALLER_FILE") (in out/HenSurf/)"
+        fi
     fi
 fi
 echo "   Build log: out/HenSurf/build.log"
 echo ""
-echo "🚀 To run HenSurf (from chromium/src directory):"
+echo "🚀 To run HenSurf (from $CHROMIUM_SRC_DIR directory):"
+
+# Define EXE_SUFFIX for Windows
+EXE_SUFFIX=""
+if [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]]; then
+    EXE_SUFFIX=".exe"
+fi
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
     if [ -d "out/HenSurf/HenSurf.app" ]; then
         echo "   open out/HenSurf/HenSurf.app"
     else
         echo "   ./out/HenSurf/chrome  (App bundle creation failed or was skipped)"
     fi
+elif [[ "$OSTYPE" == "cygwin"* ]] || [[ "$OSTYPE" == "msys"* ]] || [[ "$OSTYPE" == "win32"* ]]; then
+    echo "   ./out/HenSurf/chrome${EXE_SUFFIX}"
 else # For Linux and other OSes
     echo "   ./out/HenSurf/chrome"
 fi

--- a/scripts/setup-logo.sh
+++ b/scripts/setup-logo.sh
@@ -74,14 +74,29 @@ cat > "$CHROMIUM_SRC/chrome/app/chrome_exe.ver" << EOF
 EOF
 
 # Update app icon references in BUILD.gn files
-echo "Updating BUILD.gn icon references..."
-if [ -f "$CHROMIUM_SRC/chrome/app/BUILD.gn" ]; then
+# echo "Updating BUILD.gn icon references..." # Section commented out
+# The following section related to modifying chrome/app/BUILD.gn for icon paths
+# has been commented out because:
+# 1. The original sed command `sed -i.bak 's/chromium\/product_logo/chromium\/product_logo/g'` was a no-operation,
+#    replacing a string with itself. It provided no functional change.
+# 2. Chromium typically handles icons by looking for specific filenames (e.g., product_logo_*.png, app.icns, chrome.ico)
+#    within designated theme directories (e.g., chrome/app/theme/chromium/, default_100_percent, etc.).
+#    The rest of this script correctly places the HenSurf icons into these directories with the expected names.
+# 3. If specific BUILD.gn modifications were truly necessary (e.g., to change target names or file paths
+#    if non-standard names/locations were used), a more targeted and accurate sed command or gn edit operation
+#    would be required.
+# As such, directly modifying BUILD.gn with the provided sed command is unnecessary and potentially misleading.
+
+# if [ -f "$CHROMIUM_SRC/chrome/app/BUILD.gn" ]; then
     # Backup original BUILD.gn
-    cp "$CHROMIUM_SRC/chrome/app/BUILD.gn" "$CHROMIUM_SRC/chrome/app/BUILD.gn.backup"
+    # cp "$CHROMIUM_SRC/chrome/app/BUILD.gn" "$CHROMIUM_SRC/chrome/app/BUILD.gn.backup-hensurf-logo-setup" # Changed backup name for clarity
     
     # Update icon references (this is a simplified approach)
-    sed -i.bak 's/chromium\/product_logo/chromium\/product_logo/g' "$CHROMIUM_SRC/chrome/app/BUILD.gn"
-fi
+    # sed -i.bak 's/chromium\/product_logo/chromium\/product_logo/g' "$CHROMIUM_SRC/chrome/app/BUILD.gn"
+    # if [ -f "$CHROMIUM_SRC/chrome/app/BUILD.gn.bak" ]; then # Check if .bak was created by sed
+    #    rm "$CHROMIUM_SRC/chrome/app/BUILD.gn.bak"
+    # fi
+# fi
 
 # Create macOS app icon (ICNS) if on macOS
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
This change introduces modifications to the existing shell scripts to enable building HenSurf in a Windows environment, primarily using Git Bash.

Key changes include:
- `install-deps.sh`: Added a Windows-specific section to guide you on installing Python, Git, Ninja, and Visual Studio C++ Build Tools. Includes checks for these dependencies.
- `fetch-chromium.sh`: Implemented a Windows-compatible disk space check.
- `build.sh`: Added Windows-specific system requirements checks (RAM, CPU cores, disk space). Includes steps to build the `mini_installer` on Windows.
- `apply-patches.sh`: Made minor adjustments for Windows compatibility, primarily in logging disk space, and added a check for the `patch` utility.
- `setup-logo.sh`: Reviewed for Windows compatibility; commented out a no-op `sed` command.

The `README.md` has been updated with a detailed "Building on Windows" section, outlining prerequisites and step-by-step instructions.

These changes allow you to follow a guided process to compile HenSurf on Windows using Git Bash and the provided scripts. Further testing on a dedicated Windows environment is recommended to ensure full functionality.