### PR TITLE
feat: Implement interactive build system and revamp README

### DIFF
--- a/README_backup.md
+++ b/README_backup.md
@@ -88,37 +88,16 @@ Building Chromium (and thus HenSurf) on Windows has specific prerequisites and r
     This script applies HenSurf's modifications to the Chromium source.
 6.  **Build HenSurf:**
     ```bash
-    ./scripts/interactive_build.sh
+    ./scripts/build.sh
     ```
-    This script provides an interactive menu to choose your build target (e.g., Native OS, Linux x64, Windows x64, macOS). This is the **recommended** way to build HenSurf.
-    The build process is very lengthy (can take multiple hours, or even days depending on your CPU and RAM. Please have more than 16GB!).
+    This compiles the browser. This is also a very very very lengthy process (can take multiple hours, or even hundreds! depending on your CPU and RAM. Please have more then 16GB!).
 
-**Output Directory Structure:**
+**Running HenSurf on Windows:**
 
-Builds for different targets will now reside in separate, target-specific directories under `chromium/src/out/`. This allows you to maintain multiple builds for different operating systems or architectures simultaneously.
-
-Examples of output directory names:
-*   `HenSurf-linux-x64`
-*   `HenSurf-mac-arm64`
-*   `HenSurf-mac-x64`
-*   `HenSurf-win-x64`
-
-If you run `scripts/build.sh` directly without `HENSURF_` environment variables, it will build for your native OS and architecture in a directory like `HenSurf-<your_os>-<your_arch>`.
-
-**Running HenSurf:**
-
-After a successful build, the main executable and any installers will be located within the target-specific output directory. For example:
-
-*   **Windows:**
-    *   Executable: `chromium/src/out/HenSurf-win-x64/chrome.exe`
-    *   Installer (if built): `chromium/src/out/HenSurf-win-x64/mini_installer.exe` or `setup.exe`
-*   **macOS:**
-    *   App Bundle: `chromium/src/out/HenSurf-mac-arm64/HenSurf.app` (for ARM64) or `chromium/src/out/HenSurf-mac-x64/HenSurf.app` (for Intel x64)
-    *   Installer (if built): `chromium/src/out/HenSurf-mac-<arch>/*.dmg`
-*   **Linux:**
-    *   Executable: `chromium/src/out/HenSurf-linux-x64/chrome`
-
-Always replace `<os>` and `<arch>` with the specific target you built for.
+*   After a successful build, the main executable will be located at:
+    `chromium/src/out/HenSurf/chrome.exe`
+*   An installer might also be created (the name can vary):
+    `chromium/src/out/HenSurf/mini_installer.exe` or `chromium/src/out/HenSurf/setup.exe`
 
 **Important Notes for Windows Builds:**
 
@@ -130,43 +109,28 @@ Always replace `<os>` and `<arch>` with the specific target you built for.
 
 ## Quick Start
 
-The following steps are a general guide. Windows users, please refer to the "Building on Windows" section above for specific Windows prerequisites and detailed environment setup. For all users, the new interactive build script is the recommended way to compile HenSurf.
+The following steps are a general guide. Windows users, please refer to the "Building on Windows" section above for specific prerequisites and detailed environment setup.
 
-1.  **Install Dependencies:**
-    ```bash
-    ./scripts/install-deps.sh
-    ```
-    This script will guide you through initial setup, including `depot_tools`. Pay attention to its output, especially for Windows setup.
+1. Install dependencies:
+   ```bash
+   ./scripts/install-deps.sh
+   ```
+   This script will guide you through initial setup, including `depot_tools`.
 
-2.  **Download Chromium Source Code:**
-    ```bash
-    ./scripts/fetch-chromium.sh
-    ```
-    This downloads the entire Chromium source. It's a large download and can take a significant amount of time.
+2. Download Chromium source:
+   ```bash
+   ./scripts/fetch-chromium.sh
+   ```
 
-3.  **Apply HenSurf Customizations:**
-    ```bash
-    ./scripts/apply-patches.sh
-    ```
-    This script applies HenSurf's modifications to the Chromium source code.
+3. Apply HenSurf patches:
+   ```bash
+   ./scripts/apply-patches.sh
+   ```
 
-4.  **Build HenSurf (Recommended Method):**
-    ```bash
-    ./scripts/interactive_build.sh
-    ```
-    This script presents a menu to choose your build target:
-    *   **1. Native OS:** Automatically detects your current operating system and CPU architecture (e.g., `arm64` or `x64` on macOS).
-    *   **2. Linux (x64):** Cross-compiles for Linux x64.
-    *   **3. Windows (x64):** Cross-compiles for Windows x64.
-    *   **4. macOS (Intel x64):** Cross-compiles for macOS on Intel x64.
-    *   **5. macOS (ARM64):** Cross-compiles for macOS on ARM64 (Apple Silicon).
-    *   **6. macOS (Both Intel x64 and ARM64):** Builds for both macOS architectures. It will build for your native Mac architecture first, then the other.
-    *   **7. Exit:** Cancels the build.
-
-    The build process is very lengthy and resource-intensive. Output will be in a target-specific directory like `chromium/src/out/HenSurf-<os>-<arch>`.
-
-5.  **Alternative Build Method (`build.sh`):**
-    You can still invoke `scripts/build.sh` directly. If run without specific `HENSURF_TARGET_OS`, `HENSURF_TARGET_CPU`, or `HENSURF_OUTPUT_DIR` environment variables, it will default to building for your native OS and architecture, placing artifacts in a directory like `chromium/src/out/HenSurf-<native_os>-<native_arch>`. For more complex scenarios or CI, `build.sh` can be used with these environment variables to precisely control the build target and output location.
+4. Build HenSurf:
+   ```bash
+   ./scripts/build.sh
+   ```
 
 ## Project Structure
 
@@ -180,8 +144,7 @@ HenSurf/
 │   ├── fetch-chromium.sh  # Download Chromium source
 │   ├── apply-patches.sh   # Apply HenSurf customizations
 │   ├── setup-logo.sh      # Integrate HenSurf logo
-    ├── build.sh           # Core build script (can be parameterized)
-    ├── interactive_build.sh # Recommended interactive build script
+│   ├── build.sh           # Build the browser
 │   └── test-hensurf.sh    # Test the built browser
 ├── patches/               # Source code modifications
 │   ├── remove-ai-features.patch
@@ -224,16 +187,10 @@ If you encounter issues while building or running HenSurf, here are some common 
     ```bash
     ./scripts/install-deps.sh
     ```
-*   **Clean Build Directory**: Sometimes, previous build artifacts can cause issues. If you suspect a corrupted build state, you can remove the specific target output directory before rebuilding. For example, if your Linux x64 build failed:
-    ```bash
-    # Be careful with rm -rf!
-    rm -rf chromium/src/out/HenSurf-linux-x64
-    ```
-    Then, re-run `scripts/interactive_build.sh` or `scripts/build.sh`.
-*   **Check Logs**: Build and runtime logs can provide valuable information about what went wrong. Look for error messages in the console output. HenSurf build logs are now located in the target-specific output directory, e.g.:
-    `chromium/src/out/HenSurf-<os>-<arch>/build.log`
-*   **Disk Space**: Ensure you have sufficient free disk space (at least 150GB recommended, more if building for multiple targets) as Chromium's source and build files are very large.
-*   **Memory Usage**: Building Chromium is memory-intensive. If the build fails with errors related to memory, ensure you have enough RAM (16GB+ recommended, 32GB+ for a smoother experience) and close other memory-heavy applications.
+*   **Clean Build Directory**: Sometimes, previous build artifacts can cause issues. Clean your build directory (typically `chromium/src/out/HenSurf`) and try again.
+*   **Check Logs**: Build and runtime logs can provide valuable information about what went wrong. Look for error messages in the console output. HenSurf build logs are typically found in `chromium/src/out/HenSurf/build.log`.
+*   **Disk Space**: Ensure you have sufficient free disk space (at least 150GB recommended) as Chromium's source and build files are very large.
+*   **Memory Usage**: Building Chromium is memory-intensive. If the build fails with errors related to memory, ensure you have enough RAM (16GB+ recommended) and close other memory-heavy applications.
 *   **Consult Chromium Documentation**: For issues related to the underlying Chromium build system, the official [Chromium build documentation](https://www.chromium.org/developers/how-tos/get-the-code/) can be a helpful resource.
 
 ## Contributing

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,18 +10,87 @@ SCRIPT_DIR_BUILD=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # shellcheck source=scripts/utils.sh
 source "$SCRIPT_DIR_BUILD/utils.sh"
 
-# Define Project Root and log file path (relative to project root)
+# Define Project Root
 PROJECT_ROOT=$(cd "$SCRIPT_DIR_BUILD/.." &>/dev/null && pwd)
-CHROMIUM_SRC_DIR="$PROJECT_ROOT/chromium/src" # Define early for log path
-BUILD_LOG_FILE="$CHROMIUM_SRC_DIR/out/HenSurf/build.log" # Log inside out/HenSurf
+CHROMIUM_SRC_DIR="$PROJECT_ROOT/chromium/src"
 
-# Ensure out/HenSurf directory exists for the log file
-mkdir -p "$CHROMIUM_SRC_DIR/out/HenSurf"
+# --- Environment Variable Handling & Default Values ---
+HOST_OS_TYPE=$(get_os_type) # Used for native defaults
+
+# Determine FINAL_TARGET_OS
+if [ -z "$HENSURF_TARGET_OS" ]; then
+    FINAL_TARGET_OS="$HOST_OS_TYPE"
+    log_info "HENSURF_TARGET_OS not set, defaulting to native OS: $FINAL_TARGET_OS"
+else
+    FINAL_TARGET_OS="$HENSURF_TARGET_OS"
+    log_info "Using HENSURF_TARGET_OS: $FINAL_TARGET_OS"
+fi
+
+# Determine FINAL_TARGET_CPU
+if [ -z "$HENSURF_TARGET_CPU" ]; then
+    NATIVE_CPU_ARCH=""
+    if [[ "$HOST_OS_TYPE" == "mac" ]]; then
+        _UNAME_M_OUTPUT=$(uname -m)
+        if [[ "$_UNAME_M_OUTPUT" == "x86_64" ]]; then
+            NATIVE_CPU_ARCH="x64"
+        elif [[ "$_UNAME_M_OUTPUT" == "arm64" ]]; then
+            NATIVE_CPU_ARCH="arm64"
+        else
+            log_warn "Unknown macOS arch from uname -m: $_UNAME_M_OUTPUT. Defaulting to x64."
+            NATIVE_CPU_ARCH="x64" # Default for unknown Mac arch
+        fi
+    elif [[ "$HOST_OS_TYPE" == "linux" ]]; then
+        _UNAME_M_OUTPUT=$(uname -m)
+        if [[ "$_UNAME_M_OUTPUT" == "x86_64" ]]; then NATIVE_CPU_ARCH="x64";
+        elif [[ "$_UNAME_M_OUTPUT" == "aarch64" ]]; then NATIVE_CPU_ARCH="arm64";
+        elif [[ "$_UNAME_M_OUTPUT" == "armv7l" ]]; then NATIVE_CPU_ARCH="arm"; # example for 32-bit arm
+        else NATIVE_CPU_ARCH="x64"; log_warn "Unknown Linux arch: $_UNAME_M_OUTPUT. Defaulting to x64."; fi
+    elif [[ "$HOST_OS_TYPE" == "win" ]]; then
+        if [[ "$PROCESSOR_ARCHITECTURE" == "AMD64" ]] || [[ "$PROCESSOR_ARCHITECTURE" == "EM64T" ]]; then NATIVE_CPU_ARCH="x64";
+        elif [[ "$PROCESSOR_ARCHITECTURE" == "ARM64" ]]; then NATIVE_CPU_ARCH="arm64";
+        # Add more Windows arch checks if necessary, e.g. x86
+        else NATIVE_CPU_ARCH="x64"; log_warn "Unknown Windows arch: $PROCESSOR_ARCHITECTURE. Defaulting to x64."; fi
+    else
+        log_warn "Unknown host OS type: $HOST_OS_TYPE. Defaulting target CPU to x64."
+        NATIVE_CPU_ARCH="x64" # Fallback for unknown OS
+    fi
+    FINAL_TARGET_CPU="$NATIVE_CPU_ARCH"
+    log_info "HENSURF_TARGET_CPU not set, defaulting to detected native CPU: $FINAL_TARGET_CPU for host OS $HOST_OS_TYPE"
+else
+    FINAL_TARGET_CPU="$HENSURF_TARGET_CPU"
+    log_info "Using HENSURF_TARGET_CPU: $FINAL_TARGET_CPU"
+fi
+
+# Determine FINAL_OUTPUT_DIR
+if [ -z "$HENSURF_OUTPUT_DIR" ]; then
+    # Default output dir includes OS and CPU if they were determined (even if defaulted from native)
+    # Ensure FINAL_TARGET_OS and FINAL_TARGET_CPU are non-empty before forming the path.
+    _DEFAULT_OS_FOR_PATH=${FINAL_TARGET_OS:-"unknownOS"}
+    _DEFAULT_CPU_FOR_PATH=${FINAL_TARGET_CPU:-"unknownCPU"}
+    FINAL_OUTPUT_DIR="out/HenSurf-${_DEFAULT_OS_FOR_PATH}-${_DEFAULT_CPU_FOR_PATH}"
+    log_info "HENSURF_OUTPUT_DIR not set, defaulting to: $FINAL_OUTPUT_DIR"
+else
+    FINAL_OUTPUT_DIR="$HENSURF_OUTPUT_DIR"
+    log_info "Using HENSURF_OUTPUT_DIR: $FINAL_OUTPUT_DIR"
+fi
+
+# Log file path (relative to CHROMIUM_SRC_DIR)
+# Ensure FINAL_OUTPUT_DIR is valid before using it in path construction
+if [[ -z "$FINAL_OUTPUT_DIR" || "$FINAL_OUTPUT_DIR" == "/" ]]; then
+    log_error "FINAL_OUTPUT_DIR is empty or invalid ('$FINAL_OUTPUT_DIR'). Cannot proceed."
+    exit 1
+fi
+BUILD_LOG_FILE="$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/build.log"
+
+# Ensure output directory exists for the log file and build artifacts
+mkdir -p "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR"
 # Clear previous log file or create if not exists
 >"$BUILD_LOG_FILE"
 
+log_info "🔨 Building HenSurf Browser for $FINAL_TARGET_OS ($FINAL_TARGET_CPU)..." | tee -a "$BUILD_LOG_FILE"
+log_info "   Output directory (relative to $CHROMIUM_SRC_DIR): $FINAL_OUTPUT_DIR" | tee -a "$BUILD_LOG_FILE"
+log_info "   Build log: $BUILD_LOG_FILE" | tee -a "$BUILD_LOG_FILE"
 
-log_info "🔨 Building HenSurf Browser..." | tee -a "$BUILD_LOG_FILE"
 
 # Check if Chromium source exists
 if [ ! -d "$CHROMIUM_SRC_DIR" ]; then
@@ -30,13 +99,14 @@ if [ ! -d "$CHROMIUM_SRC_DIR" ]; then
 fi
 log_success "✅ Chromium source directory found: $CHROMIUM_SRC_DIR" | tee -a "$BUILD_LOG_FILE"
 
-# Check if patches have been applied (args.gn is a good indicator)
-if [ ! -f "$CHROMIUM_SRC_DIR/out/HenSurf/args.gn" ]; then
-    log_error "❌ HenSurf configuration (args.gn) not found in $CHROMIUM_SRC_DIR/out/HenSurf. Please run ./scripts/apply-patches.sh first." | tee -a "$BUILD_LOG_FILE"
+# Check if essential HenSurf config (e.g. from apply-patches.sh) exists.
+# This is a proxy check; args.gn will be specific to the build dir.
+# We assume if scripts/apply-patches.sh was run, essential files under build/config/hensurf/ are present.
+if [ ! -f "$PROJECT_ROOT/config/hensurf.gn" ]; then
+    log_error "❌ HenSurf base configuration (e.g., config/hensurf.gn) not found. Please run ./scripts/apply-patches.sh or ensure config is in place." | tee -a "$BUILD_LOG_FILE"
     exit 1
 fi
-log_success "✅ HenSurf configuration (args.gn) found." | tee -a "$BUILD_LOG_FILE"
-
+log_success "✅ HenSurf base configuration (config/hensurf.gn) found." | tee -a "$BUILD_LOG_FILE"
 
 # Depot Tools Setup
 DEPOT_TOOLS_DIR=$(get_depot_tools_dir "$PROJECT_ROOT")
@@ -73,15 +143,15 @@ cd "$CHROMIUM_SRC_DIR"
 log_info "Current directory: $(pwd)" | tee -a "$BUILD_LOG_FILE"
 
 
-# Check system requirements
-log_info "🔍 Checking system requirements..." | tee -a "$BUILD_LOG_FILE"
-OS_TYPE_BUILD=$(get_os_type)
+# Check system requirements (these checks are for the HOST machine running the build)
+log_info "🔍 Checking HOST system requirements..." | tee -a "$BUILD_LOG_FILE"
+# HOST_OS_TYPE is already determined above
 MEMORY_GB=0
 CPU_CORES=1 # Default to 1 core if detection fails
 
-case "$OS_TYPE_BUILD" in
-    "macos")
-        log_info "🍏 Checking macOS system requirements..." | tee -a "$BUILD_LOG_FILE"
+case "$HOST_OS_TYPE" in
+    "mac") # Changed from "macos" to "mac" to match get_os_type
+        log_info "🍏 Checking macOS host system requirements..." | tee -a "$BUILD_LOG_FILE"
         MEMORY_GB=$(sysctl -n hw.memsize | awk '{print int($1/1024/1024/1024)}')
         CPU_CORES=$(sysctl -n hw.ncpu)
         ;;
@@ -108,10 +178,10 @@ case "$OS_TYPE_BUILD" in
         log_info "💻 Checking Windows system requirements..." | tee -a "$BUILD_LOG_FILE"
         if ! command_exists "wmic"; then
             log_warn "⚠️ 'wmic' command not found. Cannot check system requirements accurately." | tee -a "$BUILD_LOG_FILE"
-            MEMORY_GB=0
-            CPU_CORES=1
+            MEMORY_GB=0 # Default if wmic fails
+            CPU_CORES=1 # Default if wmic fails
         else
-            TOTAL_MEM_KB_STR=$(wmic OS get TotalVisibleMemorySize /value | tr -d '\r' | grep TotalVisibleMemorySize | cut -d'=' -f2)
+            TOTAL_MEM_KB_STR=$(wmic OS get TotalVisibleMemorySize /value 2>/dev/null | tr -d '\r' | grep TotalVisibleMemorySize | cut -d'=' -f2)
             if [[ -n "$TOTAL_MEM_KB_STR" && "$TOTAL_MEM_KB_STR" =~ ^[0-9]+$ ]]; then
                 MEMORY_GB=$(awk -v memkb="$TOTAL_MEM_KB_STR" 'BEGIN { printf "%.0f", memkb / 1024 / 1024 }')
             else
@@ -119,7 +189,7 @@ case "$OS_TYPE_BUILD" in
                 MEMORY_GB=0
             fi
 
-            CPU_CORES_STR=$(wmic cpu get NumberOfLogicalProcessors /value | tr -d '\r' | grep NumberOfLogicalProcessors | cut -d'=' -f2)
+            CPU_CORES_STR=$(wmic cpu get NumberOfLogicalProcessors /value 2>/dev/null | tr -d '\r' | grep NumberOfLogicalProcessors | cut -d'=' -f2)
             if [[ -n "$CPU_CORES_STR" && "$CPU_CORES_STR" =~ ^[0-9]+$ ]]; then
                 CPU_CORES=$CPU_CORES_STR
             else
@@ -129,42 +199,44 @@ case "$OS_TYPE_BUILD" in
         fi
         ;;
     *)
-        log_warn "⚠️ Unsupported OS ($OS_TYPE_BUILD) for detailed system checks. Proceeding with default assumptions (0GB RAM, 1 CPU core)." | tee -a "$BUILD_LOG_FILE"
+        log_warn "⚠️ Unsupported host OS ($HOST_OS_TYPE) for detailed system checks. Proceeding with default assumptions (0GB RAM, 1 CPU core)." | tee -a "$BUILD_LOG_FILE"
         MEMORY_GB=0
         CPU_CORES=1
         ;;
 esac
 log_info "   Detected RAM: ${MEMORY_GB}GB, CPU Cores: $CPU_CORES" | tee -a "$BUILD_LOG_FILE"
 
-MIN_RAM_GB=16
+MIN_RAM_GB=16 # Recommended RAM for building Chromium
 if [ "$MEMORY_GB" -lt "$MIN_RAM_GB" ]; then
-    if [ "$MEMORY_GB" -gt 0 ]; then
-        log_warn "⚠️  Warning: Only ${MEMORY_GB}GB RAM detected. ${MIN_RAM_GB}GB+ recommended for building Chromium." | tee -a "$BUILD_LOG_FILE"
-    elif [[ "$OS_TYPE_BUILD" == "windows" || "$OS_TYPE_BUILD" == "macos" || "$OS_TYPE_BUILD" == "linux" ]]; then
-        log_warn "⚠️  Warning: Could not reliably determine system RAM. ${MIN_RAM_GB}GB+ recommended for building Chromium." | tee -a "$BUILD_LOG_FILE"
+    if [ "$MEMORY_GB" -gt 0 ]; then # If memory detection worked but is low
+        log_warn "⚠️  Warning: Only ${MEMORY_GB}GB RAM detected on host. ${MIN_RAM_GB}GB+ recommended for building Chromium." | tee -a "$BUILD_LOG_FILE"
+    elif [[ "$HOST_OS_TYPE" == "win" || "$HOST_OS_TYPE" == "mac" || "$HOST_OS_TYPE" == "linux" ]]; then # If specific OS where detection might have failed
+        log_warn "⚠️  Warning: Could not reliably determine host system RAM or it is less than ${MIN_RAM_GB}GB. ${MIN_RAM_GB}GB+ recommended for building Chromium." | tee -a "$BUILD_LOG_FILE"
     fi
-    if [[ "$OS_TYPE_BUILD" == "windows" || "$OS_TYPE_BUILD" == "macos" || "$OS_TYPE_BUILD" == "linux" || "$MEMORY_GB" -gt 0 ]]; then
-        read -p "Continue anyway? (y/N): " -n 1 -r
+    # Ask to continue only if RAM is detected as low, or if detection failed on a known OS type.
+    if [[ "$MEMORY_GB" -lt "$MIN_RAM_GB" && ("$MEMORY_GB" -gt 0 || "$HOST_OS_TYPE" == "win" || "$HOST_OS_TYPE" == "mac" || "$HOST_OS_TYPE" == "linux") ]]; then
+        read -r -p "Continue anyway? (y/N): " REPLY
         echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
             log_error "User aborted due to low RAM." | tee -a "$BUILD_LOG_FILE"
             exit 1
         fi
     fi
 fi
 
-# Check available disk space
-MIN_BUILD_DISK_SPACE_GB=50
+# Check available disk space on HOST
+MIN_BUILD_DISK_SPACE_GB=50 # Required disk space for the build output and src
 AVAILABLE_SPACE_GB=0
 
-case "$OS_TYPE_BUILD" in
-    "macos"|"linux")
-        AVAILABLE_SPACE_GB=$(df -BG . | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d '[:space:]')
-        log_info "Disk space check ($OS_TYPE_BUILD): ${AVAILABLE_SPACE_GB}GB available in $(pwd)." | tee -a "$BUILD_LOG_FILE"
+case "$HOST_OS_TYPE" in
+    "mac"|"linux") # Corrected "macos" to "mac"
+        AVAILABLE_SPACE_GB=$(df -BG "$CHROMIUM_SRC_DIR" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//' | tr -d '[:space:]')
+        if ! [[ "$AVAILABLE_SPACE_GB" =~ ^[0-9]+$ ]]; then AVAILABLE_SPACE_GB=0; fi # Default to 0 if parsing failed
+        log_info "Disk space check ($HOST_OS_TYPE) for $CHROMIUM_SRC_DIR: ${AVAILABLE_SPACE_GB}GB available." | tee -a "$BUILD_LOG_FILE"
         ;;
-    "windows")
-        log_info "💻 Checking disk space on Windows in $(pwd)..." | tee -a "$BUILD_LOG_FILE"
-        CURRENT_DRIVE_LETTER_BUILD=$(pwd -W | cut -d':' -f1)
+    "win") # Corrected "windows" to "win"
+        log_info "💻 Checking disk space on Windows in $CHROMIUM_SRC_DIR..." | tee -a "$BUILD_LOG_FILE"
+        CURRENT_DRIVE_LETTER_BUILD=$(echo "$CHROMIUM_SRC_DIR" | cut -d':' -f1)
         if ! command_exists "wmic"; then
             log_warn "⚠️ 'wmic' command not found. Cannot check disk space accurately on Windows." | tee -a "$BUILD_LOG_FILE"
             AVAILABLE_SPACE_GB=0
@@ -172,50 +244,36 @@ case "$OS_TYPE_BUILD" in
             AVAILABLE_BYTES_STR_BUILD=$(wmic logicaldisk where "DeviceID='${CURRENT_DRIVE_LETTER_BUILD}:'" get FreeSpace /value | tr -d '\r' | grep FreeSpace | cut -d'=' -f2)
             if [[ -z "$AVAILABLE_BYTES_STR_BUILD" || ! "$AVAILABLE_BYTES_STR_BUILD" =~ ^[0-9]+$ ]]; then
                  log_warn "⚠️ Could not determine free space using wmic for drive ${CURRENT_DRIVE_LETTER_BUILD}: (Output: '$AVAILABLE_BYTES_STR_BUILD')." | tee -a "$BUILD_LOG_FILE"
-                 AVAILABLE_SPACE_GB=0
+                 AVAILABLE_SPACE_GB=0 # Default if wmic fails
             else
                 AVAILABLE_SPACE_GB=$(awk -v bytes="$AVAILABLE_BYTES_STR_BUILD" 'BEGIN { printf "%.0f", bytes / 1024 / 1024 / 1024 }')
             fi
         fi
-        log_info "Drive ${CURRENT_DRIVE_LETTER_BUILD}: has approximately ${AVAILABLE_SPACE_GB}GB free." | tee -a "$BUILD_LOG_FILE"
+        log_info "Drive ${CURRENT_DRIVE_LETTER_BUILD}: (for $CHROMIUM_SRC_DIR) has approximately ${AVAILABLE_SPACE_GB}GB free." | tee -a "$BUILD_LOG_FILE"
         ;;
     *)
-        log_warn "⚠️ Unsupported OS for disk space check: $OS_TYPE_BUILD. Assuming ${MIN_BUILD_DISK_SPACE_GB}GB available." | tee -a "$BUILD_LOG_FILE"
+        log_warn "⚠️ Unsupported host OS for disk space check: $HOST_OS_TYPE. Assuming ${MIN_BUILD_DISK_SPACE_GB}GB available." | tee -a "$BUILD_LOG_FILE"
         AVAILABLE_SPACE_GB=${MIN_BUILD_DISK_SPACE_GB} # Assume enough for unknown OS
         ;;
 esac
 
 if ! [[ "$AVAILABLE_SPACE_GB" =~ ^[0-9]+$ ]]; then # Sanitize if not a number
-    log_warn "⚠️ Could not reliably determine available disk space in $(pwd). Detected: '$AVAILABLE_SPACE_GB'." | tee -a "$BUILD_LOG_FILE"
-    AVAILABLE_SPACE_GB=0
+    log_warn "⚠️ Could not reliably determine available disk space for $CHROMIUM_SRC_DIR. Detected: '$AVAILABLE_SPACE_GB'. Defaulting to 0 for check." | tee -a "$BUILD_LOG_FILE"
+    AVAILABLE_SPACE_GB=0 # Treat as 0 if not a number
 fi
 
 if [ "$AVAILABLE_SPACE_GB" -lt "$MIN_BUILD_DISK_SPACE_GB" ]; then
-    log_warn "⚠️  Warning: Only ${AVAILABLE_SPACE_GB}GB detected as available in $(pwd). Build output requires ~${MIN_BUILD_DISK_SPACE_GB}GB." | tee -a "$BUILD_LOG_FILE"
-    read -p "Continue anyway? (y/N): " -n 1 -r
+    log_warn "⚠️  Warning: Only ${AVAILABLE_SPACE_GB}GB detected as available for $CHROMIUM_SRC_DIR. Build output requires ~${MIN_BUILD_DISK_SPACE_GB}GB." | tee -a "$BUILD_LOG_FILE"
+    read -r -p "Continue anyway? (y/N): " REPLY
     echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
         log_error "User aborted due to low disk space." | tee -a "$BUILD_LOG_FILE"
         exit 1
     fi
 fi
 
-# Determine target_cpu for macOS
-GN_ARGS_EXTRA_OS=""
-if [[ "$OS_TYPE_BUILD" == "macos" ]]; then
-    HOST_ARCH=$(uname -m)
-    if [[ "$HOST_ARCH" == "arm64" ]]; then
-        log_info "🍏 Detected Apple Silicon (arm64). Setting target_cpu=arm64." | tee -a "$BUILD_LOG_FILE"
-        GN_ARGS_EXTRA_OS="target_cpu=\"arm64\""
-    elif [[ "$HOST_ARCH" == "x86_64" ]]; then
-        log_info "🍏 Detected Intel (x86_64). Setting target_cpu=x64." | tee -a "$BUILD_LOG_FILE"
-        GN_ARGS_EXTRA_OS="target_cpu=\"x64\""
-    else
-        log_warn "⚠️ Unknown macOS architecture: $HOST_ARCH. Using default target_cpu from args.gn." | tee -a "$BUILD_LOG_FILE"
-    fi
-fi
 
-# Feature flags
+# Feature flags (can be overridden by command-line args)
 HENSURF_ENABLE_BLOATWARE=0 # Default to disabled
 BUILD_CHROMEDRIVER=true
 BUILD_MINI_INSTALLER=true
@@ -238,40 +296,68 @@ GN_ARGS_LIST=()
 if [ "$DEV_FAST_MODE" = true ]; then
     log_info "🚀 Developer Fast Mode enabled: is_component_build=true, treat_warnings_as_errors=false" | tee -a "$BUILD_LOG_FILE"
     GN_ARGS_LIST+=("is_component_build=true")
+    # For faster local builds, treat_warnings_as_errors=false can be helpful
+    # However, for CI or release builds, it's better to have it true.
+    # This could be a command-line flag or based on build type.
     GN_ARGS_LIST+=("treat_warnings_as_errors=false")
 fi
-if [[ -n "$GN_ARGS_EXTRA_OS" ]]; then
-    GN_ARGS_LIST+=("$GN_ARGS_EXTRA_OS")
-fi
-GN_ARGS_LIST+=("hensurf_enable_bloatware=$HENSURF_ENABLE_BLOATWARE")
 
-GN_ARGS_STRING=""
+# Add core target OS and CPU to GN ARGS
+# These are derived from HENSURF_TARGET_OS/CPU or native host detection
+GN_ARGS_LIST+=("target_os=\"$FINAL_TARGET_OS\"")
+GN_ARGS_LIST+=("target_cpu=\"$FINAL_TARGET_CPU\"")
+
+# Add other feature flags from command line or defaults
+GN_ARGS_LIST+=("hensurf_enable_bloatware=$HENSURF_ENABLE_BLOATWARE")
+# Ensure important HenSurf configurations are included.
+# These might be implicitly imported by `import("//build/config/hensurf/hensurf.gn")`
+# in the main args.gn file of the output directory, or explicitly set here.
+# For example: `import("//build/config/compiler/compiler.gni")`
+#              `import("//build/config/features.gni")`
+#              `is_official_build=false`
+#              `is_chrome_branded=false`
+#              `is_debug=false` (for release builds)
+#              `dcheck_always_on=false` (for release builds)
+#              `symbol_level=0` (for release builds to reduce size)
+#              `blink_symbol_level=0` (for release builds)
+
+# Construct the final GN args string
+GN_ARGS_STRING_WITH_TARGETS=""
 for item in "${GN_ARGS_LIST[@]}"; do
-    [[ -z "$GN_ARGS_STRING" ]] && GN_ARGS_STRING="$item" || GN_ARGS_STRING="$GN_ARGS_STRING $item"
+    if [ -z "$GN_ARGS_STRING_WITH_TARGETS" ]; then
+        GN_ARGS_STRING_WITH_TARGETS="$item"
+    else
+        GN_ARGS_STRING_WITH_TARGETS="$GN_ARGS_STRING_WITH_TARGETS $item"
+    fi
 done
 
-# Generate build files
-log_info "⚙️  Generating build files..." | tee -a "$BUILD_LOG_FILE"
+# Generate build files using FINAL_OUTPUT_DIR
+# The args.gn file within $FINAL_OUTPUT_DIR should contain `import("//build/config/hensurf/hensurf.gn")`
+# to load all HenSurf specific build arguments.
+log_info "⚙️  Generating build files in $FINAL_OUTPUT_DIR..." | tee -a "$BUILD_LOG_FILE"
 log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Starting gn generation..." | tee -a "$BUILD_LOG_FILE"
-if [[ -n "$GN_ARGS_STRING" ]]; then
-    log_info "   With GN_ARGS: $GN_ARGS_STRING" | tee -a "$BUILD_LOG_FILE"
-    gn gen out/HenSurf --args="$GN_ARGS_STRING" 2>&1 | tee -a "$BUILD_LOG_FILE"
-else
-    gn gen out/HenSurf 2>&1 | tee -a "$BUILD_LOG_FILE"
-fi
-GN_GEN_STATUS=${PIPESTATUS[0]}
+log_info "   GN ARGS to be applied: $GN_ARGS_STRING_WITH_TARGETS" | tee -a "$BUILD_LOG_FILE"
+log_info "   Target output directory for gn: $FINAL_OUTPUT_DIR" | tee -a "$BUILD_LOG_FILE"
+
+# The command `gn gen` will create $FINAL_OUTPUT_DIR if it doesn't exist,
+# and create an args.gn file within it, then populate the build tree.
+# If args.gn already exists, it will be overwritten with these command-line args.
+gn gen "$FINAL_OUTPUT_DIR" --args="$GN_ARGS_STRING_WITH_TARGETS" 2>&1 | tee -a "$BUILD_LOG_FILE"
+GN_GEN_STATUS=${PIPESTATUS[0]} # Get status of gn gen command
+
 log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Finished gn generation." | tee -a "$BUILD_LOG_FILE"
 
 if [ $GN_GEN_STATUS -ne 0 ]; then
-    log_error "❌ Failed to generate build files. Check the configuration and $BUILD_LOG_FILE." | tee -a "$BUILD_LOG_FILE"
+    log_error "❌ Failed to generate build files in $FINAL_OUTPUT_DIR. Check the configuration and $BUILD_LOG_FILE." | tee -a "$BUILD_LOG_FILE"
+    log_error "   Make sure that '$FINAL_OUTPUT_DIR/args.gn' is correctly configured, potentially by including 'import(\"//build/config/hensurf/hensurf.gn\")'." | tee -a "$BUILD_LOG_FILE"
     exit 1
 fi
 
-# Show build configuration
-log_info "📋 Build configuration:" | tee -a "$BUILD_LOG_FILE"
-gn args out/HenSurf --list --short 2>&1 | tee -a "$BUILD_LOG_FILE"
+# Show build configuration from the generated output directory
+log_info "📋 Build configuration for $FINAL_OUTPUT_DIR (from gn args $FINAL_OUTPUT_DIR --list --short):" | tee -a "$BUILD_LOG_FILE"
+gn args "$FINAL_OUTPUT_DIR" --list --short 2>&1 | tee -a "$BUILD_LOG_FILE"
 
-# Estimate build time
+# Estimate build time (based on HOST capabilities)
 BASE_BUILD_HOURS=8
 if [[ -n "$HENSURF_BASE_BUILD_HOURS" && "$HENSURF_BASE_BUILD_HOURS" =~ ^[0-9]+([.][0-9]+)?$ && $(echo "$HENSURF_BASE_BUILD_HOURS > 0" | bc -l) -eq 1 ]]; then
     BASE_BUILD_HOURS=$HENSURF_BASE_BUILD_HOURS
@@ -291,15 +377,17 @@ log_info "   Memory: ${MEMORY_GB}GB" | tee -a "$BUILD_LOG_FILE"
 log_info "   Estimated time: ~${ESTIMATED_HOURS} (This is a VERY ROUGH estimate.)" | tee -a "$BUILD_LOG_FILE"
 log_info "" | tee -a "$BUILD_LOG_FILE"
 log_info "⏳ This will take a while. You can monitor progress in another terminal with:" | tee -a "$BUILD_LOG_FILE"
-log_info "   tail -f $BUILD_LOG_FILE" | tee -a "$BUILD_LOG_FILE" # Corrected log file path
+log_info "   tail -f \"$BUILD_LOG_FILE\"" | tee -a "$BUILD_LOG_FILE"
 log_info "" | tee -a "$BUILD_LOG_FILE"
 
-# Build HenSurf (chrome target)
-log_info "🔨 Building HenSurf browser..." | tee -a "$BUILD_LOG_FILE"
-log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Starting main browser build (autoninja chrome)..." | tee -a "$BUILD_LOG_FILE"
+# Build HenSurf (chrome target) using FINAL_OUTPUT_DIR
+log_info "🔨 Building HenSurf browser (chrome target) in $FINAL_OUTPUT_DIR..." | tee -a "$BUILD_LOG_FILE"
+log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Starting main browser build (autoninja -C \"$FINAL_OUTPUT_DIR\" chrome)..." | tee -a "$BUILD_LOG_FILE"
 log_info "Ninja will now show detailed build progress (e.g., [X/Y] files compiled)..." | tee -a "$BUILD_LOG_FILE"
-autoninja -C out/HenSurf chrome 2>&1 | tee -a "$BUILD_LOG_FILE"
-CHROME_BUILD_STATUS=${PIPESTATUS[0]}
+
+autoninja -C "$FINAL_OUTPUT_DIR" chrome 2>&1 | tee -a "$BUILD_LOG_FILE"
+CHROME_BUILD_STATUS=${PIPESTATUS[0]} # Get status of autoninja command
+
 log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Finished main browser build." | tee -a "$BUILD_LOG_FILE"
 
 if command_exists "ccache"; then
@@ -308,26 +396,27 @@ if command_exists "ccache"; then
 fi
 
 if [ $CHROME_BUILD_STATUS -ne 0 ]; then
-    log_error "❌ Build failed for chrome target. Check $BUILD_LOG_FILE for details." | tee -a "$BUILD_LOG_FILE"
+    log_error "❌ Build failed for chrome target in $FINAL_OUTPUT_DIR. Check $BUILD_LOG_FILE for details." | tee -a "$BUILD_LOG_FILE"
     exit 1
 fi
 
 # Build additional components
 EXE_SUFFIX=""
-[[ "$OS_TYPE_BUILD" == "windows" ]] && EXE_SUFFIX=".exe"
+# Use FINAL_TARGET_OS for determining suffix, not HOST_OS_TYPE
+[[ "$FINAL_TARGET_OS" == "win" ]] && EXE_SUFFIX=".exe"
 
 if [ "$BUILD_CHROMEDRIVER" = true ]; then
-    log_info "🔨 Building chromedriver..." | tee -a "$BUILD_LOG_FILE"
-    if [ -f "out/HenSurf/chromedriver$EXE_SUFFIX" ]; then
-        log_info "ℹ️ chromedriver artifact already exists. Skipping build." | tee -a "$BUILD_LOG_FILE"
+    log_info "🔨 Building chromedriver in $FINAL_OUTPUT_DIR..." | tee -a "$BUILD_LOG_FILE"
+    if [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/chromedriver$EXE_SUFFIX" ]; then
+        log_info "ℹ️ chromedriver artifact already exists in $FINAL_OUTPUT_DIR. Skipping build." | tee -a "$BUILD_LOG_FILE"
     else
         log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Starting optional component build: chromedriver..." | tee -a "$BUILD_LOG_FILE"
-        autoninja -C out/HenSurf chromedriver 2>&1 | tee -a "$BUILD_LOG_FILE"
+        autoninja -C "$FINAL_OUTPUT_DIR" chromedriver 2>&1 | tee -a "$BUILD_LOG_FILE"
         CHROMEDRIVER_BUILD_STATUS=${PIPESTATUS[0]}
         if [[ $CHROMEDRIVER_BUILD_STATUS -ne 0 ]]; then
-            log_warn "⚠️ Optional component chromedriver failed to build (exit code $CHROMEDRIVER_BUILD_STATUS). Continuing with the main build." | tee -a "$BUILD_LOG_FILE"
+            log_warn "⚠️ Optional component chromedriver failed to build (exit code $CHROMEDRIVER_BUILD_STATUS) in $FINAL_OUTPUT_DIR. Continuing." | tee -a "$BUILD_LOG_FILE"
         else
-            log_success "✅ Optional component chromedriver built successfully." | tee -a "$BUILD_LOG_FILE"
+            log_success "✅ Optional component chromedriver built successfully in $FINAL_OUTPUT_DIR." | tee -a "$BUILD_LOG_FILE"
         fi
         log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Finished optional component build: chromedriver." | tee -a "$BUILD_LOG_FILE"
     fi
@@ -336,58 +425,83 @@ else
 fi
 
 # Create application bundle for macOS (and build macOS installer)
-if [[ "$OS_TYPE_BUILD" == "macos" ]]; then
-    log_info "📦 Creating macOS application bundle..." | tee -a "$BUILD_LOG_FILE"
-    if [ -d "out/HenSurf/HenSurf.app" ]; then
-        rm -rf out/HenSurf/HenSurf.app
+# This section should only run if the TARGET OS is mac
+if [[ "$FINAL_TARGET_OS" == "mac" ]]; then
+    log_info "📦 Creating macOS application bundle in $FINAL_OUTPUT_DIR..." | tee -a "$BUILD_LOG_FILE"
+    if [ -d "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app" ]; then
+        log_info "HenSurf.app already exists in $FINAL_OUTPUT_DIR. Removing before creating a new one." | tee -a "$BUILD_LOG_FILE"
+        rm -rf "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app"
     fi
 
-    EXPECTED_CHROMIUM_APP_NAME="Chromium.app" # Default app name for is_chrome_branded=false
+    # Determine the name of the app generated by Chromium build (usually Chromium.app or Google Chrome.app)
+    # For is_chrome_branded=false (likely for HenSurf), it's Chromium.app
+    EXPECTED_CHROMIUM_APP_NAME="Chromium.app"
+
     APP_COPIED=false
-    if [ -d "out/HenSurf/${EXPECTED_CHROMIUM_APP_NAME}" ]; then
-        log_info "Found ${EXPECTED_CHROMIUM_APP_NAME}, copying to HenSurf.app..." | tee -a "$BUILD_LOG_FILE"
-        cp -R "out/HenSurf/${EXPECTED_CHROMIUM_APP_NAME}" "out/HenSurf/HenSurf.app"
+    if [ -d "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/${EXPECTED_CHROMIUM_APP_NAME}" ]; then
+        log_info "Found ${EXPECTED_CHROMIUM_APP_NAME} in $FINAL_OUTPUT_DIR, copying to HenSurf.app..." | tee -a "$BUILD_LOG_FILE"
+        cp -R "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/${EXPECTED_CHROMIUM_APP_NAME}" "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app"
         APP_COPIED=true
+    else
+        # Fallback for other potential names if necessary, or error out
+        log_warn "⚠️ Could not find ${EXPECTED_CHROMIUM_APP_NAME} in $FINAL_OUTPUT_DIR. Trying other common names..." | tee -a "$BUILD_LOG_FILE"
+        # Example: if it could be Google Chrome.app
+        # if [ -d "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/Google Chrome.app" ]; then
+        #    EXPECTED_CHROMIUM_APP_NAME="Google Chrome.app"
+        #    cp -R "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/${EXPECTED_CHROMIUM_APP_NAME}" "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app"
+        #    APP_COPIED=true
+        # fi
     fi
 
-    if [ "$APP_COPIED" = true ] && [ -d "out/HenSurf/HenSurf.app" ]; then
-        PLIST_BUDDY="/usr/libexec/PlistBuddy"
-        INFO_PLIST="out/HenSurf/HenSurf.app/Contents/Info.plist"
-        # Values from hensurf.gn or project defaults
-        TARGET_MACOS_VERSION="10.15"
-        HENSURF_VERSION="1.0.0"
-        HENSURF_BUILD_NUMBER="1"
+    if [ "$APP_COPIED" = true ] && [ -d "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app" ]; then
+        PLIST_BUDDY="/usr/libexec/PlistBuddy" # Standard macOS utility
+        INFO_PLIST="$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app/Contents/Info.plist"
 
+        # These values should ideally come from a centralized configuration (e.g. hensurf.gn or a version file)
+        TARGET_MACOS_MIN_VERSION="10.15" # Example, ensure this matches Chromium's capabilities
+        HENSURF_VERSION_STR="1.0.0" # Example
+        HENSURF_BUILD_NUMBER_STR="1" # Example
+
+        # Check if PlistBuddy is available (it should be on macOS host)
+        # The actual modification of Info.plist should ideally happen on a macOS host.
+        # If cross-compiling, this step might be skipped or handled differently.
         if command_exists "$PLIST_BUDDY" && [ -f "$INFO_PLIST" ]; then
             log_info "Updating Info.plist at: $INFO_PLIST" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :CFBundleName HenSurf" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set CFBundleName" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :CFBundleDisplayName HenSurf Browser" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set CFBundleDisplayName" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :CFBundleIdentifier com.hensurf.browser" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set CFBundleIdentifier" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $HENSURF_VERSION" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set CFBundleShortVersionString" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :CFBundleVersion $HENSURF_BUILD_NUMBER" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set CFBundleVersion" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :LSMinimumSystemVersion $TARGET_MACOS_VERSION" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set LSMinimumSystemVersion" | tee -a "$BUILD_LOG_FILE"
-            "$PLIST_BUDDY" -c "Set :CFBundleIconFile app.icns" "$INFO_PLIST" 2>/dev/null || log_warn "Warning: Failed to set CFBundleIconFile" | tee -a "$BUILD_LOG_FILE"
-            log_success "✅ HenSurf.app bundle created and Info.plist configured successfully!" | tee -a "$BUILD_LOG_FILE"
+            # Set common bundle properties
+            "$PLIST_BUDDY" -c "Set :CFBundleName HenSurf" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set CFBundleName" | tee -a "$BUILD_LOG_FILE"
+            "$PLIST_BUDDY" -c "Set :CFBundleDisplayName HenSurf Browser" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set CFBundleDisplayName" | tee -a "$BUILD_LOG_FILE"
+            "$PLIST_BUDDY" -c "Set :CFBundleIdentifier com.hensurf.browser" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set CFBundleIdentifier" | tee -a "$BUILD_LOG_FILE"
+            "$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $HENSURF_VERSION_STR" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set CFBundleShortVersionString" | tee -a "$BUILD_LOG_FILE"
+            "$PLIST_BUDDY" -c "Set :CFBundleVersion $HENSURF_BUILD_NUMBER_STR" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set CFBundleVersion" | tee -a "$BUILD_LOG_FILE"
+            "$PLIST_BUDDY" -c "Set :LSMinimumSystemVersion $TARGET_MACOS_MIN_VERSION" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set LSMinimumSystemVersion" | tee -a "$BUILD_LOG_FILE"
+            # Assuming app.icns is copied from a branding package or default location
+            # "$PLIST_BUDDY" -c "Set :CFBundleIconFile app.icns" "$INFO_PLIST" >/dev/null 2>&1 || log_warn "Warning: Failed to set CFBundleIconFile" | tee -a "$BUILD_LOG_FILE"
+            log_success "✅ HenSurf.app bundle created and Info.plist configured successfully in $FINAL_OUTPUT_DIR!" | tee -a "$BUILD_LOG_FILE"
         else
-            log_warn "⚠️  PlistBuddy tool ($PLIST_BUDDY) or Info.plist ($INFO_PLIST) not found. Cannot customize app bundle." | tee -a "$BUILD_LOG_FILE"
+            if [[ "$HOST_OS_TYPE" == "mac" ]]; then # Only warn if on macOS host and it failed
+                 log_warn "⚠️  PlistBuddy tool ($PLIST_BUDDY) not found, or Info.plist ($INFO_PLIST) missing. Cannot customize app bundle." | tee -a "$BUILD_LOG_FILE"
+            else
+                 log_info "ℹ️  Skipping Info.plist customization (PlistBuddy typically only available on macOS host)." | tee -a "$BUILD_LOG_FILE"
+            fi
         fi
     else
-        log_warn "⚠️  Could not find the expected base app bundle '${EXPECTED_CHROMIUM_APP_NAME}' in out/HenSurf/ to create HenSurf.app." | tee -a "$BUILD_LOG_FILE"
+        log_warn "⚠️  Could not find or copy the base app bundle '${EXPECTED_CHROMIUM_APP_NAME}' in $CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR to create HenSurf.app." | tee -a "$BUILD_LOG_FILE"
     fi
 
     if [ "$BUILD_MINI_INSTALLER" = true ]; then
-        log_info "📦 Building macOS installer (dmg)..." | tee -a "$BUILD_LOG_FILE"
-        DMG_CHECK_FILE=$(ls out/HenSurf/*.dmg 2>/dev/null | head -n 1)
+        log_info "📦 Building macOS installer (dmg) in $FINAL_OUTPUT_DIR..." | tee -a "$BUILD_LOG_FILE"
+        # Check if a .dmg already exists in the output directory
+        DMG_CHECK_FILE=$(ls "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR"/*.dmg 2>/dev/null | head -n 1)
         if [ -f "$DMG_CHECK_FILE" ]; then
-            log_info "ℹ️ macOS installer artifact ($DMG_CHECK_FILE) already exists. Skipping build." | tee -a "$BUILD_LOG_FILE"
+            log_info "ℹ️ macOS installer artifact ($DMG_CHECK_FILE) already exists in $FINAL_OUTPUT_DIR. Skipping build." | tee -a "$BUILD_LOG_FILE"
         else
             log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Starting optional component build: macOS mini_installer..." | tee -a "$BUILD_LOG_FILE"
-            autoninja -C out/HenSurf mini_installer 2>&1 | tee -a "$BUILD_LOG_FILE"
+            autoninja -C "$FINAL_OUTPUT_DIR" mini_installer 2>&1 | tee -a "$BUILD_LOG_FILE"
             MINI_INSTALLER_MACOS_BUILD_STATUS=${PIPESTATUS[0]}
             if [[ $MINI_INSTALLER_MACOS_BUILD_STATUS -ne 0 ]]; then
-                log_warn "⚠️ Optional component macOS mini_installer failed to build (exit code $MINI_INSTALLER_MACOS_BUILD_STATUS). Continuing." | tee -a "$BUILD_LOG_FILE"
+                log_warn "⚠️ Optional component macOS mini_installer failed to build (exit code $MINI_INSTALLER_MACOS_BUILD_STATUS) in $FINAL_OUTPUT_DIR. Continuing." | tee -a "$BUILD_LOG_FILE"
             else
-                log_success "✅ Optional component macOS mini_installer built successfully." | tee -a "$BUILD_LOG_FILE"
+                log_success "✅ Optional component macOS mini_installer built successfully in $FINAL_OUTPUT_DIR." | tee -a "$BUILD_LOG_FILE"
             fi
             log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Finished optional component build: macOS mini_installer." | tee -a "$BUILD_LOG_FILE"
         fi
@@ -395,31 +509,31 @@ if [[ "$OS_TYPE_BUILD" == "macos" ]]; then
         log_info "ℹ️ Skipping macOS installer build as per --skip-mini-installer flag." | tee -a "$BUILD_LOG_FILE"
     fi
 
-elif [[ "$OS_TYPE_BUILD" == "windows" ]]; then
+# This section is for Windows target builds
+elif [[ "$FINAL_TARGET_OS" == "win" ]]; then
     if [ "$BUILD_MINI_INSTALLER" = true ]; then
-        log_info "📦 Building Windows installer (mini_installer)..." | tee -a "$BUILD_LOG_FILE"
-        if [ -f "out/HenSurf/mini_installer.exe" ] || [ -f "out/HenSurf/setup.exe" ]; then
-             log_info "ℹ️ Windows installer artifact (mini_installer.exe or setup.exe) already exists. Skipping build." | tee -a "$BUILD_LOG_FILE"
+        log_info "📦 Building Windows installer (mini_installer) in $FINAL_OUTPUT_DIR..." | tee -a "$BUILD_LOG_FILE"
+        if [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/mini_installer.exe" ] || [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/setup.exe" ]; then # Common names for installer
+             log_info "ℹ️ Windows installer artifact already exists in $FINAL_OUTPUT_DIR. Skipping build." | tee -a "$BUILD_LOG_FILE"
         else
             log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Starting optional component build: Windows mini_installer..." | tee -a "$BUILD_LOG_FILE"
-            autoninja -C out/HenSurf mini_installer 2>&1 | tee -a "$BUILD_LOG_FILE"
+            autoninja -C "$FINAL_OUTPUT_DIR" mini_installer 2>&1 | tee -a "$BUILD_LOG_FILE"
             MINI_INSTALLER_WIN_BUILD_STATUS=${PIPESTATUS[0]}
             if [[ $MINI_INSTALLER_WIN_BUILD_STATUS -ne 0 ]]; then
-                log_warn "⚠️ Optional component Windows mini_installer failed to build (exit code $MINI_INSTALLER_WIN_BUILD_STATUS). Continuing." | tee -a "$BUILD_LOG_FILE"
+                log_warn "⚠️ Optional component Windows mini_installer failed to build (exit code $MINI_INSTALLER_WIN_BUILD_STATUS) in $FINAL_OUTPUT_DIR. Continuing." | tee -a "$BUILD_LOG_FILE"
             else
-                log_success "✅ Optional component Windows mini_installer built successfully." | tee -a "$BUILD_LOG_FILE"
+                log_success "✅ Optional component Windows mini_installer built successfully in $FINAL_OUTPUT_DIR." | tee -a "$BUILD_LOG_FILE"
             fi
             log_info "[$(date '+%Y-%m-%d %H:%M:%S')] Finished optional component build: Windows mini_installer." | tee -a "$BUILD_LOG_FILE"
         fi
-        if [ -f "out/HenSurf/mini_installer.exe" ]; then
-            log_success "✅ Windows mini_installer.exe found." | tee -a "$BUILD_LOG_FILE"
-        elif [ -f "out/HenSurf/setup.exe" ]; then
-            log_success "✅ Windows setup.exe found." | tee -a "$BUILD_LOG_FILE"
+        # Check for common installer names after build attempt
+        if [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/mini_installer.exe" ]; then
+            log_success "✅ Windows mini_installer.exe found in $FINAL_OUTPUT_DIR." | tee -a "$BUILD_LOG_FILE"
+        elif [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/setup.exe" ]; then # Chromium often names it setup.exe
+            log_success "✅ Windows setup.exe found in $FINAL_OUTPUT_DIR." | tee -a "$BUILD_LOG_FILE"
         else
-            # This warning is valid if the build was attempted and failed, or if it succeeded but produced an unexpected name.
-            # If the build was skipped, this warning might be misleading.
-            # However, the current logic attempts build only if not found, so this should be okay.
-            log_warn "⚠️  Windows installer (mini_installer.exe or setup.exe) not found in out/HenSurf/ after build attempt." | tee -a "$BUILD_LOG_FILE"
+             # This warning is valid if the build was attempted and expected to succeed
+            log_warn "⚠️  Windows installer (mini_installer.exe or setup.exe) not found in $CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR after build attempt." | tee -a "$BUILD_LOG_FILE"
         fi
     else
         log_info "ℹ️ Skipping Windows installer build as per --skip-mini-installer flag." | tee -a "$BUILD_LOG_FILE"
@@ -427,55 +541,58 @@ elif [[ "$OS_TYPE_BUILD" == "windows" ]]; then
 fi
 
 log_info "" | tee -a "$BUILD_LOG_FILE"
-log_success "🎉 HenSurf build completed successfully!" | tee -a "$BUILD_LOG_FILE"
+log_success "🎉 HenSurf build for $FINAL_TARGET_OS-$FINAL_TARGET_CPU completed successfully!" | tee -a "$BUILD_LOG_FILE"
 log_info "" | tee -a "$BUILD_LOG_FILE"
 log_info "📍 Build artifacts location (relative to $CHROMIUM_SRC_DIR):" | tee -a "$BUILD_LOG_FILE"
-log_info "   Main executable: out/HenSurf/chrome${EXE_SUFFIX}" | tee -a "$BUILD_LOG_FILE"
+log_info "   Main executable: $FINAL_OUTPUT_DIR/chrome${EXE_SUFFIX}" | tee -a "$BUILD_LOG_FILE"
 
-if [ "$BUILD_CHROMEDRIVER" = true ] && [ -f "out/HenSurf/chromedriver${EXE_SUFFIX}" ]; then
-    log_info "   ChromeDriver:    out/HenSurf/chromedriver${EXE_SUFFIX}" | tee -a "$BUILD_LOG_FILE"
+if [ "$BUILD_CHROMEDRIVER" = true ] && [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/chromedriver${EXE_SUFFIX}" ]; then
+    log_info "   ChromeDriver:    $FINAL_OUTPUT_DIR/chromedriver${EXE_SUFFIX}" | tee -a "$BUILD_LOG_FILE"
 fi
 
-if [[ "$OS_TYPE_BUILD" == "macos" ]]; then
-    if [ -d "out/HenSurf/HenSurf.app" ]; then
-        log_info "   macOS App Bundle: out/HenSurf/HenSurf.app" | tee -a "$BUILD_LOG_FILE"
+# Use FINAL_TARGET_OS for these checks
+if [[ "$FINAL_TARGET_OS" == "mac" ]]; then
+    if [ -d "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app" ]; then
+        log_info "   macOS App Bundle: $FINAL_OUTPUT_DIR/HenSurf.app" | tee -a "$BUILD_LOG_FILE"
     fi
     if [ "$BUILD_MINI_INSTALLER" = true ]; then
-        DMG_FILE=$(ls out/HenSurf/*.dmg 2>/dev/null | head -n 1)
+        DMG_FILE=$(ls "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR"/*.dmg 2>/dev/null | head -n 1) # Check for any .dmg file
         if [ -f "$DMG_FILE" ]; then
-            log_info "   macOS Installer:  $(basename "$DMG_FILE") (in out/HenSurf/)" | tee -a "$BUILD_LOG_FILE"
-        elif [ -f "out/HenSurf/HenSurf.dmg" ]; then
-             log_info "   macOS Installer:  HenSurf.dmg (in out/HenSurf/)" | tee -a "$BUILD_LOG_FILE"
+            log_info "   macOS Installer:  $(basename "$DMG_FILE") (in $FINAL_OUTPUT_DIR/)" | tee -a "$BUILD_LOG_FILE"
+        elif [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.dmg" ]; then # Check for specific name if generic one not found
+             log_info "   macOS Installer:  HenSurf.dmg (in $FINAL_OUTPUT_DIR/)" | tee -a "$BUILD_LOG_FILE"
         fi
     fi
-elif [[ "$OS_TYPE_BUILD" == "windows" ]]; then
+elif [[ "$FINAL_TARGET_OS" == "win" ]]; then
     if [ "$BUILD_MINI_INSTALLER" = true ]; then
-        if [ -f "out/HenSurf/mini_installer.exe" ]; then
-            log_info "   Windows Installer: out/HenSurf/mini_installer.exe" | tee -a "$BUILD_LOG_FILE"
-        elif [ -f "out/HenSurf/setup.exe" ]; then
-            log_info "   Windows Installer: out/HenSurf/setup.exe" | tee -a "$BUILD_LOG_FILE"
+        if [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/mini_installer.exe" ]; then
+            log_info "   Windows Installer: $FINAL_OUTPUT_DIR/mini_installer.exe" | tee -a "$BUILD_LOG_FILE"
+        elif [ -f "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/setup.exe" ]; then # Chromium often names it setup.exe
+            log_info "   Windows Installer: $FINAL_OUTPUT_DIR/setup.exe" | tee -a "$BUILD_LOG_FILE"
         else
-            WIN_INSTALLER_FILE=$(ls out/HenSurf/*installer.exe 2>/dev/null | head -n 1)
+            # Check for any file that looks like an installer if specific names aren't found
+            WIN_INSTALLER_FILE=$(ls "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR"/*installer.exe 2>/dev/null | head -n 1)
             if [ -f "$WIN_INSTALLER_FILE" ]; then
-                 log_info "   Windows Installer: $(basename "$WIN_INSTALLER_FILE") (in out/HenSurf/)" | tee -a "$BUILD_LOG_FILE"
+                 log_info "   Windows Installer: $(basename "$WIN_INSTALLER_FILE") (in $FINAL_OUTPUT_DIR/)" | tee -a "$BUILD_LOG_FILE"
             fi
         fi
     fi
 fi
-log_info "   Build log: $BUILD_LOG_FILE" | tee -a "$BUILD_LOG_FILE" # Corrected log file path
+log_info "   Build log: $BUILD_LOG_FILE" | tee -a "$BUILD_LOG_FILE"
 log_info "" | tee -a "$BUILD_LOG_FILE"
 log_info "🚀 To run HenSurf (from $CHROMIUM_SRC_DIR directory):" | tee -a "$BUILD_LOG_FILE"
 
-if [[ "$OS_TYPE_BUILD" == "macos" ]]; then
-    if [ -d "out/HenSurf/HenSurf.app" ]; then
-        log_info "   open out/HenSurf/HenSurf.app" | tee -a "$BUILD_LOG_FILE"
+# Use FINAL_TARGET_OS for run instructions
+if [[ "$FINAL_TARGET_OS" == "mac" ]]; then
+    if [ -d "$CHROMIUM_SRC_DIR/$FINAL_OUTPUT_DIR/HenSurf.app" ]; then
+        log_info "   open $FINAL_OUTPUT_DIR/HenSurf.app" | tee -a "$BUILD_LOG_FILE"
     else
-        log_info "   ./out/HenSurf/chrome  (App bundle creation failed or was skipped)" | tee -a "$BUILD_LOG_FILE"
+        log_info "   ./$FINAL_OUTPUT_DIR/chrome  (App bundle creation failed or was skipped)" | tee -a "$BUILD_LOG_FILE"
     fi
-elif [[ "$OS_TYPE_BUILD" == "windows" ]]; then
-    log_info "   ./out/HenSurf/chrome${EXE_SUFFIX}" | tee -a "$BUILD_LOG_FILE"
-else
-    log_info "   ./out/HenSurf/chrome" | tee -a "$BUILD_LOG_FILE"
+elif [[ "$FINAL_TARGET_OS" == "win" ]]; then
+    log_info "   ./$FINAL_OUTPUT_DIR/chrome${EXE_SUFFIX}" | tee -a "$BUILD_LOG_FILE"
+else # Assuming Linux or other POSIX-like
+    log_info "   ./$FINAL_OUTPUT_DIR/chrome" | tee -a "$BUILD_LOG_FILE"
 fi
 log_info "" | tee -a "$BUILD_LOG_FILE"
 log_info "📋 HenSurf features:" | tee -a "$BUILD_LOG_FILE"

--- a/scripts/interactive_build.sh
+++ b/scripts/interactive_build.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# Source utility functions
+# shellcheck disable=SC1091
+source "$(dirname "$0")/utils.sh"
+
+# Function to determine native CPU architecture
+get_native_cpu_arch() {
+  local os_type
+  os_type=$(get_os_type)
+  if [[ "$os_type" == "mac" ]]; then
+    # On macOS, uname -m can return arm64 or x86_64
+    local arch
+    arch=$(uname -m)
+    if [[ "$arch" == "arm64" ]]; then
+      echo "arm64"
+    else
+      echo "x64"
+    fi
+  elif [[ "$os_type" == "linux" ]]; then
+    # On Linux, uname -m typically returns x86_64 for x64
+    local arch
+    arch=$(uname -m)
+    if [[ "$arch" == "x86_64" ]]; then
+      echo "x64"
+    elif [[ "$arch" == "aarch64" ]]; then
+      echo "arm64" # Or however you want to represent ARM on Linux
+    else
+      echo "x64" # Default to x64 if unsure
+    fi
+  elif [[ "$os_type" == "win" ]];
+  then
+    # For Windows, CPU_ARCHITECTURE is usually x86 or AMD64
+    # We'll assume x64 for simplicity as per requirements
+    if [[ "$PROCESSOR_ARCHITECTURE" == "AMD64" ]] || [[ "$PROCESSOR_ARCHITECTURE" == "EM64T" ]]; then
+        echo "x64"
+    elif [[ "$PROCESSOR_ARCHITECTURE" == "ARM64" ]]; then
+        echo "arm64"
+    else
+        # Default or add more specific checks if necessary
+        echo "x64"
+    fi
+  else
+    # Default for unknown OS, or handle error
+    echo "x64"
+  fi
+}
+
+# Function to perform the build
+perform_build() {
+  log_info "Starting build for OS: $HENSURF_TARGET_OS, CPU: $HENSURF_TARGET_CPU"
+  log_info "Output directory: $HENSURF_OUTPUT_DIR"
+
+  export HENSURF_TARGET_OS
+  export HENSURF_TARGET_CPU
+  export HENSURF_OUTPUT_DIR
+
+  if bash "./scripts/build.sh"; then
+    log_success "Build completed successfully for $HENSURF_TARGET_OS-$HENSURF_TARGET_CPU."
+  else
+    log_error "Build failed for $HENSURF_TARGET_OS-$HENSURF_TARGET_CPU."
+    # Optionally, exit here or let the script continue if it's part of "macOS Both"
+  fi
+}
+
+# Main script execution
+log_info "Interactive Build Script Started"
+
+# Get host OS
+HOST_OS=$(get_os_type)
+log_info "Detected Host OS: $HOST_OS"
+
+# Display menu
+echo ""
+log_action "Choose a build target:"
+echo "1. Native OS (autodetect architecture)"
+echo "2. Linux (x64)"
+echo "3. Windows (x64)"
+echo "4. macOS (Intel x64)"
+echo "5. macOS (ARM64)"
+echo "6. macOS (Both Intel x64 and ARM64)"
+echo "7. Exit"
+echo ""
+
+read -r -p "Enter your choice [1-7]: " choice
+
+case "$choice" in
+  1)
+    log_info "Selected: Native OS"
+    HENSURF_TARGET_OS="$HOST_OS"
+    HENSURF_TARGET_CPU=$(get_native_cpu_arch)
+    HENSURF_OUTPUT_DIR="out/HenSurf-${HENSURF_TARGET_OS}-${HENSURF_TARGET_CPU}"
+    perform_build
+    ;;
+  2)
+    log_info "Selected: Linux (x64)"
+    HENSURF_TARGET_OS="linux"
+    HENSURF_TARGET_CPU="x64"
+    HENSURF_OUTPUT_DIR="out/HenSurf-linux-x64"
+    perform_build
+    ;;
+  3)
+    log_info "Selected: Windows (x64)"
+    HENSURF_TARGET_OS="win" # Chromium's target_os for Windows
+    HENSURF_TARGET_CPU="x64"
+    HENSURF_OUTPUT_DIR="out/HenSurf-win-x64"
+    perform_build
+    ;;
+  4)
+    log_info "Selected: macOS (Intel x64)"
+    HENSURF_TARGET_OS="mac"
+    HENSURF_TARGET_CPU="x64"
+    HENSURF_OUTPUT_DIR="out/HenSurf-mac-x64"
+    perform_build
+    ;;
+  5)
+    log_info "Selected: macOS (ARM64)"
+    HENSURF_TARGET_OS="mac"
+    HENSURF_TARGET_CPU="arm64"
+    HENSURF_OUTPUT_DIR="out/HenSurf-mac-arm64"
+    perform_build
+    ;;
+  6)
+    log_info "Selected: macOS (Both Intel x64 and ARM64)"
+    NATIVE_MAC_ARCH=$(get_native_cpu_arch) # Check host macOS architecture
+
+    if [[ "$HOST_OS" != "mac" ]]; then
+      log_warning "Building for 'macOS Both' is intended to be run on a macOS host."
+      # Ask user if they want to proceed
+      read -r -p "Proceed anyway? (yes/no): " proceed_choice
+      if [[ "$proceed_choice" != "yes" ]]; then
+        log_info "Exiting."
+        exit 0
+      fi
+    fi
+
+    log_info "Determining build order for macOS Both..."
+    # Build native architecture first
+    if [[ "$NATIVE_MAC_ARCH" == "arm64" ]]; then
+      log_info "Host is ARM64. Building ARM64 first, then x64."
+      HENSURF_TARGET_OS="mac"
+      HENSURF_TARGET_CPU="arm64"
+      HENSURF_OUTPUT_DIR="out/HenSurf-mac-arm64"
+      perform_build
+
+      log_info "Building macOS (Intel x64) next..."
+      HENSURF_TARGET_OS="mac"
+      HENSURF_TARGET_CPU="x64"
+      HENSURF_OUTPUT_DIR="out/HenSurf-mac-x64"
+      perform_build
+    else # Native is x64 or something else (default to x64 first)
+      log_info "Host is Intel x64 (or non-ARM64). Building x64 first, then ARM64."
+      HENSURF_TARGET_OS="mac"
+      HENSURF_TARGET_CPU="x64"
+      HENSURF_OUTPUT_DIR="out/HenSurf-mac-x64"
+      perform_build
+
+      log_info "Building macOS (ARM64) next..."
+      HENSURF_TARGET_OS="mac"
+      HENSURF_TARGET_CPU="arm64"
+      HENSURF_OUTPUT_DIR="out/HenSurf-mac-arm64"
+      perform_build
+    fi
+    ;;
+  7)
+    log_info "Exiting."
+    ;;
+  *)
+    log_error "Invalid choice: $choice. Please select a number between 1 and 7."
+    exit 1
+    ;;
+esac
+
+log_info "Interactive Build Script Finished"
+exit 0


### PR DESCRIPTION
This commit introduces a new interactive build system and significantly updates the README to reflect these changes.

Key changes:

1.  **New Interactive Build Script (`scripts/interactive_build.sh`):**
    *   Provides a user-friendly menu to select build targets:
        *   Native OS (auto-detected architecture)
        *   Linux (x64)
        *   Windows (x64)
        *   macOS (Intel x64)
        *   macOS (ARM64)
        *   macOS (Both Intel x64 and ARM64)
    *   Sets appropriate environment variables (`HENSURF_TARGET_OS`, `HENSURF_TARGET_CPU`, `HENSURF_OUTPUT_DIR`) and invokes the main build script.

2.  **Modified Main Build Script (`scripts/build.sh`):**
    *   Now accepts `HENSURF_TARGET_OS`, `HENSURF_TARGET_CPU`, and `HENSURF_OUTPUT_DIR` environment variables to enable parameterized builds.
    *   If run directly, defaults to building for the host OS and architecture, outputting to a target-specific directory (e.g., `out/HenSurf-linux-x64`).
    *   All output paths, including build logs and final artifacts, are now correctly placed within the specified output directory.
    *   GN generation arguments (`target_os`, `target_cpu`) are set based on these variables.

3.  **README.md Revamp:**
    *   Updated to feature `scripts/interactive_build.sh` as the primary build method.
    *   Clearly documents the new build options and the target-specific output directory structure (e.g., `chromium/src/out/HenSurf-linux-x64`).
    *   Revised "Quick Start," platform-specific build sections, "Running HenSurf," and "Troubleshooting" sections to align with the new system.
    *   Updated the "Project Structure" section.

These changes provide a more flexible and user-friendly build experience, allowing you to easily build HenSurf for various platforms and architectures with clear output separation.