### PR TITLE
Fix: Apply shellcheck recommendations to scripts

### DIFF
--- a/scripts/apply_feature_patches.sh
+++ b/scripts/apply_feature_patches.sh
@@ -49,7 +49,7 @@ GIT_APPLY_OPTS="--reject --ignore-whitespace --unidiff-zero"
 case "$ACTION" in
   apply)
     log_info "   Applying patch: $PATCH_FILE"
-    if git apply $GIT_APPLY_OPTS "$PATCH_FILE"; then
+    if git apply "$GIT_APPLY_OPTS" "$PATCH_FILE"; then
       log_success "✅ Patch '$PATCH_FILE' applied successfully."
     else
       log_error "❌ Error applying patch '$PATCH_FILE'."
@@ -60,7 +60,7 @@ case "$ACTION" in
     ;;
   unapply)
     log_info "   Unapplying patch: $PATCH_FILE"
-    if git apply --reverse $GIT_APPLY_OPTS "$PATCH_FILE"; then
+    if git apply --reverse "$GIT_APPLY_OPTS" "$PATCH_FILE"; then
       log_success "✅ Patch '$PATCH_FILE' unapplied successfully."
     else
       log_error "❌ Error unapplying patch '$PATCH_FILE'."

--- a/shellcheck_report.txt
+++ b/shellcheck_report.txt
@@ -1,0 +1,84 @@
+Checking file: scripts/apply-patches.sh
+
+In scripts/apply-patches.sh line 9:
+source "$SCRIPT_DIR_APPLY_PATCHES/utils.sh"
+       ^-- SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+----------------------------------------
+Checking file: scripts/apply_feature_patches.sh
+
+In scripts/apply_feature_patches.sh line 13:
+source "$SCRIPT_DIR_FEATURE_PATCH/utils.sh"
+       ^-- SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+
+In scripts/apply_feature_patches.sh line 52:
+    if git apply $GIT_APPLY_OPTS "$PATCH_FILE"; then
+                 ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean:
+    if git apply "$GIT_APPLY_OPTS" "$PATCH_FILE"; then
+
+
+In scripts/apply_feature_patches.sh line 63:
+    if git apply --reverse $GIT_APPLY_OPTS "$PATCH_FILE"; then
+                           ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean:
+    if git apply --reverse "$GIT_APPLY_OPTS" "$PATCH_FILE"; then
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
+----------------------------------------
+Checking file: scripts/build.sh
+
+In scripts/build.sh line 11:
+source "$SCRIPT_DIR_BUILD/utils.sh"
+       ^--------------------------^ SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+----------------------------------------
+Checking file: scripts/fetch-chromium.sh
+
+In scripts/fetch-chromium.sh line 14:
+source "$SCRIPT_DIR/utils.sh" # utils.sh provides logging and safe_cd functions
+       ^--------------------^ SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+----------------------------------------
+Checking file: scripts/install-deps.sh
+
+In scripts/install-deps.sh line 11:
+source "$SCRIPT_DIR_REAL_INSTALL_DEPS/utils.sh"
+       ^-- SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+----------------------------------------
+Checking file: scripts/interactive_build.sh
+----------------------------------------
+Checking file: scripts/setup-logo.sh
+
+In scripts/setup-logo.sh line 11:
+source "$SCRIPT_DIR_SETUP_LOGO/utils.sh" # Provides log_* and safe_cd
+       ^-- SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+----------------------------------------
+Checking file: scripts/test-hensurf.sh
+
+In scripts/test-hensurf.sh line 11:
+source "$SCRIPT_DIR_TEST_HENSURF/utils.sh"
+       ^-- SC1091 (info): Not following: scripts/utils.sh was not specified as input (see shellcheck -x).
+
+For more information:
+  https://www.shellcheck.net/wiki/SC1091 -- Not following: scripts/utils.sh w...
+----------------------------------------
+Checking file: scripts/utils.sh
+----------------------------------------


### PR DESCRIPTION
This commit addresses SC2086 warnings in the `scripts/apply_feature_patches.sh` script by adding double quotes around the GIT_APPLY_OPTS variable. This prevents potential globbing and word splitting issues.

Shellcheck was run on all scripts, and other warnings (SC1091) were deemed informational for the current context.