### PR TITLE
Fix: Address 'gn executable not found' error in CI workflows

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -27,6 +27,17 @@ jobs:
       DEPOT_TOOLS_DIR: ${{ github.workspace }}/depot_tools
 
     steps:
+      - name: Free up runner disk space
+        run: |
+          set -e
+          echo "Initial disk space:"
+          df -h
+          sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY" /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          sudo swapoff /swapfile || true
+          sudo rm -f /swapfile || true
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
       - name: Checkout HenSurf repository
         uses: actions/checkout@v4
         with:
@@ -84,8 +95,44 @@ jobs:
       - name: Run gclient runhooks
         working-directory: ${{ github.workspace }}/chromium
         run: |
-          # This step downloads toolchains like Clang, including clang-tidy
-          gclient runhooks -j8
+          set -e
+          echo "Running gclient runhooks..."
+          gclient runhooks -j1 # Use -j1 for single-threaded execution to avoid potential resource exhaustion/race conditions
+          echo "gclient runhooks completed."
+          # Verify gn executable exists after runhooks
+          GN_EXECUTABLE="${{ github.workspace }}/chromium/src/buildtools/linux64/gn/gn"
+          if [ -f "$GN_EXECUTABLE" ]; then
+            echo "✅ gn executable found at $GN_EXECUTABLE."
+          else
+            echo "⚠️ gn executable NOT found at $GN_EXECUTABLE after gclient runhooks."
+            echo "Attempting to locate gn in depot_tools..."
+            DEPOT_TOOLS_GN_PATH="${{ env.DEPOT_TOOLS_DIR }}/gn" # gn is usually at the root of depot_tools for Linux
+            # Check if the depot_tools gn exists and is executable
+            if [ -f "$DEPOT_TOOLS_GN_PATH" ] && [ -x "$DEPOT_TOOLS_GN_PATH" ]; then
+              echo "Found gn in depot_tools at $DEPOT_TOOLS_GN_PATH."
+              # Define the target directory
+              TARGET_GN_DIR="${{ github.workspace }}/chromium/src/buildtools/linux64/gn"
+              # Create the target directory if it doesn't exist
+              mkdir -p "$TARGET_GN_DIR"
+              echo "Copying gn from $DEPOT_TOOLS_GN_PATH to $TARGET_GN_DIR/gn..."
+              cp "$DEPOT_TOOLS_GN_PATH" "$TARGET_GN_DIR/gn"
+              if [ -f "$TARGET_GN_DIR/gn" ]; then
+                echo "✅ Successfully copied gn to $TARGET_GN_DIR/gn."
+                # Ensure it's executable
+                chmod +x "$TARGET_GN_DIR/gn"
+              else
+                echo "❌ Failed to copy gn from depot_tools."
+                echo "Proceeding without gn in the expected chromium location might lead to errors."
+                # Optionally, exit 1 here if gn is absolutely critical and copying failed
+                # exit 1
+              fi
+            else
+              echo "❌ gn not found in depot_tools at $DEPOT_TOOLS_GN_PATH or it's not executable."
+              echo "Proceeding without gn in the expected chromium location might lead to errors."
+              # Optionally, exit 1 here
+              # exit 1
+            fi
+          fi
 
       - name: Apply HenSurf patches
         working-directory: ${{ github.workspace }}/chromium/src # Patches apply to the synced Chromium source

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,12 +90,61 @@ jobs:
         git fetch --depth=1 origin "$LATEST_TAG_REF"
         git checkout FETCH_HEAD
 
-    - name: Sync Dependencies and Toolchain
+    - name: Sync Dependencies, Run Hooks, and Check for GN
       working-directory: ${{ github.workspace }}/chromium
       run: |
         set -e
+        echo "Configuring gclient..."
         gclient config --spec 'solutions = [{"name": "src", "url": "https://chromium.googlesource.com/chromium/src.git", "managed": False}]'
-        gclient sync -D
+
+        echo "Running gclient sync -D -j1..." # Added -j1
+        gclient sync -D -j1
+
+        echo "Running gclient runhooks -j1 explicitly..." # Added explicit runhooks
+        gclient runhooks -j1
+        echo "gclient runhooks completed."
+
+        # Verify gn executable exists
+        GN_EXECUTABLE="${{ github.workspace }}/chromium/src/buildtools/linux64/gn/gn"
+        EXPECTED_GN_PATH_README="${{ github.workspace }}/chromium/src/buildtools/README.md"
+
+        if [ -f "$GN_EXECUTABLE" ]; then
+          echo "✅ gn executable found at $GN_EXECUTABLE."
+        else
+          echo "⚠️ gn executable NOT found at $GN_EXECUTABLE after gclient sync/runhooks."
+          echo "Listing contents of ${{ github.workspace }}/chromium/src/buildtools/linux64/ to check if gn directory was created:"
+          ls -la "${{ github.workspace }}/chromium/src/buildtools/linux64/"
+          echo "Listing contents of ${{ github.workspace }}/chromium/src/buildtools/ to see available OS dirs:"
+          ls -la "${{ github.workspace }}/chromium/src/buildtools/"
+
+          # Check if the buildtools README exists, which might indicate partial success of tool fetching
+          if [ -f "$EXPECTED_GN_PATH_README" ]; then
+            echo "ℹ️ Found buildtools README: $EXPECTED_GN_PATH_README. buildtools downloaded some content."
+          else
+            echo "⚠️ Did not find buildtools README: $EXPECTED_GN_PATH_README. buildtools might be missing entirely."
+          fi
+
+          echo "Attempting to locate gn in depot_tools..."
+          DEPOT_TOOLS_GN_PATH="${{ env.DEPOT_TOOLS_DIR }}/gn"
+
+          if [ -f "$DEPOT_TOOLS_GN_PATH" ] && [ -x "$DEPOT_TOOLS_GN_PATH" ]; then
+            echo "Found gn in depot_tools at $DEPOT_TOOLS_GN_PATH."
+            TARGET_GN_DIR="${{ github.workspace }}/chromium/src/buildtools/linux64/gn"
+            mkdir -p "$TARGET_GN_DIR"
+            echo "Copying gn from $DEPOT_TOOLS_GN_PATH to $TARGET_GN_DIR/gn..."
+            cp "$DEPOT_TOOLS_GN_PATH" "$TARGET_GN_DIR/gn"
+            if [ -f "$TARGET_GN_DIR/gn" ]; then
+              echo "✅ Successfully copied gn to $TARGET_GN_DIR/gn."
+              chmod +x "$TARGET_GN_DIR/gn"
+            else
+              echo "❌ Failed to copy gn from depot_tools to $TARGET_GN_DIR/gn."
+              # exit 1 # Decide if this should be a fatal error for CodeQL
+            fi
+          else
+            echo "❌ gn not found in depot_tools at $DEPOT_TOOLS_GN_PATH or it's not executable."
+            # exit 1 # Decide if this should be a fatal error for CodeQL
+          fi
+        fi
 
     - name: Apply HenSurf Patches
       working-directory: ${{ github.workspace }}/chromium/src


### PR DESCRIPTION
The `clang-tidy` and `codeql` GitHub Actions workflows were failing with an error indicating that `gn.py` could not find the `gn` executable within the Chromium checkout (`src/buildtools/linux64/gn/gn`).

This commit implements the following changes to address the issue:

1.  **Free Up Disk Space (clang-tidy.yml):** Added a step to the `clang-tidy.yml` workflow to free up disk space on the runner before fetching Chromium. This is similar to a step already present in `codeql.yml` and helps prevent failures during `gclient runhooks` due to insufficient space.

2.  **Controlled Execution of `gclient runhooks` / `sync`:**
    - Modified both `clang-tidy.yml` and `codeql.yml` to run `gclient runhooks` (and `gclient sync` in `codeql.yml`) with the `-j1` flag. This ensures single-threaded execution, reducing potential resource exhaustion or race conditions on the CI runners that might have prevented `gn` from being correctly installed.
    - Explicitly added `gclient runhooks` after `gclient sync` in `codeql.yml` for clarity and to ensure hooks are definitely run.

3.  **Verify and Fallback for `gn` Executable:**
    - Added steps in both workflows after `gclient runhooks` (or its equivalent) to check for the existence of the `gn` executable at the expected path: `${{ github.workspace }}/chromium/src/buildtools/linux64/gn/gn`.
    - If `gn` is not found at this location, the workflows will now attempt to locate `gn` within the `depot_tools` directory (expected at `${{ env.DEPOT_TOOLS_DIR }}/gn`).
    - If found in `depot_tools`, it is copied to the target Chromium `buildtools` path and made executable.
    - Detailed logging has been added to these steps to aid in diagnosing any future issues with `gn` availability.

These changes aim to make the CI builds more robust by ensuring the `gn` executable is available for the `gn gen` step, which is critical for generating build files.