### PR TITLE
Fix: Ensure DEPS are processed by gclient

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -71,7 +71,6 @@ jobs:
             {
               "name": "src",
               "url": "https://chromium.googlesource.com/chromium/src.git",
-              "managed": False,
               "custom_deps": {},
               "custom_vars": {
                   "checkout_pgo_profiles": False,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         set -e
         echo "Configuring gclient..."
-        gclient config --spec 'solutions = [{"name": "src", "url": "https://chromium.googlesource.com/chromium/src.git", "managed": False}]'
+        gclient config --spec 'solutions = [{"name": "src", "url": "https://chromium.googlesource.com/chromium/src.git"}]'
 
         echo "Running gclient sync -D -j1..."
         gclient sync -D -j1


### PR DESCRIPTION
Removes `managed: False` from the `gclient config` specification in both `codeql.yml` and `clang-tidy.yml` workflows.

This change is intended to ensure that `gclient sync` and `gclient runhooks` correctly process the DEPS file for the main Chromium 'src' solution. Previously, with `managed: False`, it appeared that `gclient runhooks` was not executing any of the hooks defined in `src/DEPS`, leading to missing build tools such as `gn`'s required Python interpreter.

By removing `managed: False` (allowing it to default to `True`), `gclient` should now properly manage and execute the dependencies and hooks, populating the `chromium/src/buildtools` directory as expected.